### PR TITLE
feat(frontend): MSWセットアップとテスト雛形／.env.example 追加

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Frontend environment variables (copy to `.env`)
+
+# Backend base URL (no trailing slash)
+# example (local): http://localhost:8080
+VITE_BACKEND_URL=
+

--- a/frontend/src/__tests__/App.integration.spec.tsx
+++ b/frontend/src/__tests__/App.integration.spec.tsx
@@ -1,1 +1,49 @@
-// placeholder
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { server } from '../mocks/setup'
+import App from '../App.jsx'
+
+describe('App Integration', () => {
+  test('切替成功で ACTIVE 表示になり、pull で人数が増える', async () => {
+    // テスト専用の状態を持つ
+    let currentState: 'WAITING' | 'ACTIVE' = 'WAITING'
+    let users: string[] = []
+
+    server.use(
+      http.get('*/status', () => HttpResponse.json({ status: currentState, count: users.length })),
+      http.get('*/users.json', () => HttpResponse.json(users)),
+      http.post('*/switch-video', async ({ request }) => {
+        try {
+          const body = (await request.json()) as { videoId?: string }
+          if (!body?.videoId) return new HttpResponse('bad request', { status: 400 })
+        } catch {
+          return new HttpResponse('bad request', { status: 400 })
+        }
+        currentState = 'ACTIVE'
+        users = []
+        return new HttpResponse(null, { status: 200 })
+      }),
+      http.post('*/pull', () => {
+        users = [...users, `User-${users.length + 1}`]
+        return new HttpResponse(null, { status: 200 })
+      }),
+    )
+
+    render(<App />)
+
+    // 初期は WAITING / 0 人
+    expect(await screen.findByText('WAITING')).toBeInTheDocument()
+    expect(screen.getByText(/人数: 0/)).toBeInTheDocument()
+
+    // 切替
+    const input = screen.getByPlaceholderText('videoId') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'VID123' } })
+    fireEvent.click(screen.getByText('切替'))
+
+    await waitFor(() => expect(screen.getByText('ACTIVE')).toBeInTheDocument())
+
+    // 今すぐ取得 → 人数 1
+    fireEvent.click(screen.getByText('今すぐ取得'))
+    await waitFor(() => expect(screen.getByText(/人数: 1/)).toBeInTheDocument())
+  })
+})

--- a/frontend/src/__tests__/App.ui.spec.tsx
+++ b/frontend/src/__tests__/App.ui.spec.tsx
@@ -1,1 +1,19 @@
-// placeholder
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App.jsx'
+
+describe('App UI', () => {
+  test('表示モード切替（chip ↔ table）', async () => {
+    render(<App />)
+    // 初期は chip
+    expect(await screen.findByText('チップ')).toBeInTheDocument()
+    // table に切替
+    const modeSelect = screen.getByDisplayValue('チップ') as HTMLSelectElement
+    fireEvent.change(modeSelect, { target: { value: '表' } })
+    expect(screen.getByDisplayValue('表')).toBeInTheDocument()
+  })
+
+  test('状態バッジが WAITING を表示', async () => {
+    render(<App />)
+    expect(await screen.findByText('WAITING')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/Layout.spec.tsx
+++ b/frontend/src/__tests__/Layout.spec.tsx
@@ -1,1 +1,12 @@
-// placeholder
+import { render, screen } from '@testing-library/react'
+import App from '../App.jsx'
+
+describe('Layout', () => {
+  test('長文ユーザー名に truncate-1 クラスが適用される（チップ表示）', async () => {
+    render(<App />)
+    // NOTE: デフォルトモックではユーザーが空なので、UI クラスの存在のみ簡易確認
+    // App のチップ要素は <span class="truncate-1" ...> として描画される
+    // 初期状態でユーザーがいないため、待機バナーの存在を確認しておく
+    expect(await screen.findByText('WAITING')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export type LiveStatus = 'WAITING' | 'ACTIVE'
+
+type Props = {
+  status: LiveStatus
+}
+
+export function StatusBadge({ status }: Props) {
+  const isActive = status === 'ACTIVE'
+  const cls = `px-2 py-1 rounded font-medium ${
+    isActive ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-700'
+  }`
+  return <span className={cls}>{status}</span>
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,1 +1,64 @@
-// placeholder
+import { http, HttpResponse } from 'msw'
+
+// 簡易なメモリ状態（各テストで server.use で上書き可）
+let state: 'WAITING' | 'ACTIVE' = 'WAITING'
+let users: string[] = []
+
+export const resetMockState = () => {
+  state = 'WAITING'
+  users = []
+}
+
+export const handlers = [
+  // 状態
+  http.get('*/status', () => {
+    return HttpResponse.json({ status: state, count: users.length })
+  }),
+
+  // ユーザー一覧
+  http.get('*/users.json', () => {
+    return HttpResponse.json(users)
+  }),
+
+  // 切替
+  http.post('*/switch-video', async ({ request }) => {
+    // videoId バリデーションっぽいもの
+    try {
+      const body = (await request.json()) as { videoId?: string }
+      if (!body?.videoId) return new HttpResponse('bad request', { status: 400 })
+    } catch {
+      return new HttpResponse('bad request', { status: 400 })
+    }
+    state = 'ACTIVE'
+    users = []
+    return new HttpResponse(null, { status: 200 })
+  }),
+
+  // 今すぐ取得
+  http.post('*/pull', () => {
+    users.push(`User-${users.length + 1}`)
+    return new HttpResponse(null, { status: 200 })
+  }),
+
+  // リセット
+  http.post('*/reset', () => {
+    state = 'WAITING'
+    users = []
+    return new HttpResponse(null, { status: 200 })
+  }),
+]
+
+export const __mock = {
+  get state() {
+    return state
+  },
+  set state(v: 'WAITING' | 'ACTIVE') {
+    state = v
+  },
+  get users() {
+    return users
+  },
+  set users(v: string[]) {
+    users = v
+  },
+}

--- a/frontend/src/mocks/setup.ts
+++ b/frontend/src/mocks/setup.ts
@@ -1,1 +1,19 @@
-// placeholder
+import { beforeAll, afterAll, afterEach, vi } from 'vitest'
+import { setupServer } from 'msw/node'
+import { handlers, resetMockState } from './handlers'
+import 'whatwg-fetch'
+import '@testing-library/jest-dom/vitest'
+
+export const server = setupServer(...handlers)
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  resetMockState()
+  vi.useRealTimers()
+})
+
+afterAll(() => server.close())

--- a/frontend/src/types/env.d.ts
+++ b/frontend/src/types/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,1 +1,21 @@
-{}
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "types": ["vitest", "vite/client"]
+  },
+  "include": [
+    "src",
+    "vite.config.js"
+  ]
+}


### PR DESCRIPTION
以下を追加・更新しました。

- MSW セットアップ
  - frontend/src/mocks/handlers.ts, setup.ts を実装
  - 各テスト後に状態リセット
- サンプルテスト（Vitest + RTL + MSW）
  - App.ui.spec.tsx: 表示モード切替・WAITINGバッジ
  - App.integration.spec.tsx: 切替→ACTIVE→pull で人数増加
  - Layout.spec.tsx: レイアウト保護の雛形
- .env.example 追加（VITE_BACKEND_URL）
- TypeScript 雛形（非侵入）
  - tsconfig.json を厳格化（allowJs で段階移行）
  - src/types/env.d.ts で環境変数の型定義
- 参考コンポーネント: StatusBadge.tsx（未参照）

補足:
- docs/frontend.md は `docs/` が .gitignore のため PR には含めていません（ローカルには存在）。必要なら .gitignore 調整後に別 PR で追加可能です。
- バックエンド未実装の `/status` に対しては MSW でカバーする想定です。

確認方法:
```bash
cd frontend
npm i
npm run test
```

問題なければマージお願いします。
