### PR TITLE
test(frontend): 統合テストを安定化（data-testid=counter を使用）\n\n- App: 参加者カウンタに…

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -90,7 +90,7 @@ export default function App() {
                 <div className="rounded-lg ring-1 ring-black/5 dark:ring-white/10 bg-white/70 dark:bg-white/5 backdrop-blur px-5 py-5 md:px-6 md:py-6 flex items-end justify-between">
                   <div className="space-y-0.5">
                     <div className="text-[11px] md:text-xs text-slate-500 dark:text-slate-400 tracking-wide">参加者</div>
-                    <div className="text-3xl md:text-4xl font-semibold tabular-nums tracking-tight bg-gradient-to-br from-slate-900 to-slate-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">{users.length}</div>
+                    <div data-testid="counter" className="text-3xl md:text-4xl font-semibold tabular-nums tracking-tight bg-gradient-to-br from-slate-900 to-slate-700 dark:from-white dark:to-slate-300 bg-clip-text text-transparent">{users.length}</div>
                   </div>
                   <div className="h-10 w-px bg-slate-300/50 dark:bg-white/10"></div>
                   <div className="text-[11px] md:text-xs text-slate-500 dark:text-slate-400">状態: <span className="font-medium text-slate-700 dark:text-slate-200">{active ? 'ACTIVE' : 'WAITING'}</span></div>

--- a/frontend/src/__tests__/App.integration.spec.tsx
+++ b/frontend/src/__tests__/App.integration.spec.tsx
@@ -1,26 +1,51 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { server } from '../mocks/setup'
+import { http, HttpResponse } from 'msw'
 import App from '../App.jsx'
 
-describe('App Integration (擬似)', () => {
-  test('切替→ACTIVE、今すぐ取得→人数増加（擬似）', async () => {
-    render(<App />)
-    // 初期は ACTIVE（擬似データ）
-    expect(await screen.findAllByText('ACTIVE')).toBeTruthy()
+describe('App Integration (MSW)', () => {
+  test('切替成功で ACTIVE 表示になり、pull で人数が増える', async () => {
+    let currentState: 'WAITING' | 'ACTIVE' = 'WAITING'
+    let users: string[] = []
 
-    // 切替（videoId 入力がないとエラー）
+    server.use(
+      http.get('*/status', () => HttpResponse.json({ status: currentState, count: users.length })),
+      http.get('*/users.json', () => HttpResponse.json(users)),
+      http.post('*/switch-video', async ({ request }) => {
+        try {
+          const body = (await request.json()) as { videoId?: string }
+          if (!body?.videoId) return new HttpResponse('bad request', { status: 400 })
+        } catch {
+          return new HttpResponse('bad request', { status: 400 })
+        }
+        currentState = 'ACTIVE'
+        users = []
+        return new HttpResponse(null, { status: 200 })
+      }),
+      http.post('*/pull', () => {
+        users = [...users, `User-${users.length + 1}`]
+        return new HttpResponse(null, { status: 200 })
+      }),
+    )
+
+    render(<App />)
+
+    // 初期は WAITING / 0 人
+    expect(await screen.findByText('WAITING')).toBeInTheDocument()
+    expect(screen.getByTestId('counter')).toHaveTextContent('0')
+
+    // videoId 未入力でエラー
     fireEvent.click(screen.getByRole('button', { name: '切替' }))
     expect(await screen.findByRole('alert')).toBeInTheDocument()
 
-    // 入力して切替（擬似: seed に置き換え）
+    // 入力して切替
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'VID123' } })
     fireEvent.click(screen.getByRole('button', { name: '切替' }))
-    expect(screen.queryByRole('alert')).toBeNull()
+    await waitFor(() => expect(screen.getByText('ACTIVE')).toBeInTheDocument())
 
-    // 今すぐ取得
-    const before = screen.getByText(/参加者/).textContent as string
+    // 今すぐ取得 → 人数 1
     fireEvent.click(screen.getByRole('button', { name: '今すぐ取得' }))
-    // 参加者数表示が変化（簡易判定）
-    expect(screen.getByText(/参加者/).textContent).not.toBe(before)
+    await waitFor(() => expect(screen.getByTestId('counter')).toHaveTextContent('1'))
   })
 })


### PR DESCRIPTION
… data-testid を付与\n- test: counter を直接検証して WAITING→ACTIVE と人数増加を確認