### PR TITLE
fix: GitHub Actionsデプロイの認証エラーを修正

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -19,12 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY_JSON }}
+
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY_JSON }}
-          export_default_credentials: true
 
       - name: Configure Docker auth
         run: gcloud auth configure-docker us-central1-docker.pkg.dev -q


### PR DESCRIPTION
## Summary
• GitHub Actionsのデプロイワークフローで発生していた認証エラーを修正
• 非推奨になったパラメータを削除し、最新の認証方式に更新

## 修正内容
• `google-github-actions/auth@v2` を使用した最新の認証方式に変更
• 非推奨の `service_account_key` と `export_default_credentials` パラメータを削除
• Docker Artifact Registry への push 認証エラーを解決

## Test plan
- [x] ワークフロー設定ファイルの構文確認
- [ ] デプロイワークフローの動作確認（マージ後のmainブランチでテスト）

🤖 Generated with [Claude Code](https://claude.ai/code)