### PR TITLE
fix: Artifact Registryの正しいリポジトリ名に修正

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -14,8 +14,8 @@ jobs:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       REGION: ${{ secrets.GCP_REGION }}
       SERVICE: yt-commenters
-      REPO: backend
-      IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/backend/yt-commenters:${{ github.sha }}
+      REPO: yt-livechat
+      IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/yt-livechat/yt-commenters:${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
• GitHub ActionsのデプロイでArtifact Registryリポジトリが見つからないエラーを修正
• GCPコンソールで実際のリポジトリ名を確認して正しい名前に変更

## 問題
前回のPR #25で認証エラーは解決されましたが、新たに以下のエラーが発生：
```
name unknown: Repository "backend" not found
```

## 修正内容
• **リポジトリ名**: `backend` → `yt-livechat` に修正
• **GCPで確認した実際の設定**:
  - プロジェクト: `yt-livechat-20250912-a1871f`
  - リポジトリ: `yt-livechat` (us-central1)
  - フォーマット: DOCKER

## Test plan
- [x] GCPコンソールでリポジトリ名を確認済み
- [x] ワークフロー設定ファイルの構文確認
- [ ] デプロイワークフローの動作確認（マージ後のmainブランチでテスト）

🤖 Generated with [Claude Code](https://claude.ai/code)