### PR TITLE
feat: ユーザーリストを初回コメント日時→UserChannelIDで安定ソート

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { getStatus, getUsers, postPull, postReset, postSwitchVideo } from './utils/api'
 import { useAutoRefresh } from './hooks/useAutoRefresh'
+import { sortUsersStable } from './utils/sortUsers'
 import { LoadingButton } from './components/LoadingButton'
 
 function seed() {
@@ -23,6 +24,8 @@ export default function App() {
   const [isResetting, setIsResetting] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
 
+  // 並び順ユーティリティ（TS実装）を使用
+
   const updateClock = () => {
     const d = new Date();
     const pad = (n) => String(n).padStart(2, '0')
@@ -39,7 +42,8 @@ export default function App() {
       ])
       const status = st.status || st.Status || 'WAITING'
       setActive(status === 'ACTIVE')
-      setUsers(Array.isArray(us) ? us : [])
+      const fetched = Array.isArray(us) ? us : []
+      setUsers(sortUsersStable(fetched))
       setErrorMsg('')
     } catch (e) {
       setErrorMsg('更新に失敗しました。しばらくしてから再試行してください。')
@@ -218,7 +222,7 @@ export default function App() {
             </thead>
             <tbody className="divide-y divide-slate-200/80 dark:divide-white/10">
               {users.map((user,i)=> (
-                <tr key={`${user.channelId || user.displayName}-${i}`} className="hover:bg-neutral-50/80 dark:hover:bg-white/5 transition">
+                <tr key={`${user.channelId || user.displayName}`} className="hover:bg-neutral-50/80 dark:hover:bg-white/5 transition">
                   <td className="px-4 py-2.5 tabular-nums text-slate-600 dark:text-slate-300">{String(i+1).padStart(2,'0')}</td>
                   <td className="px-4 py-2.5 truncate-1" title={user.displayName || user}>{user.displayName || user}</td>
                   <td className="px-4 py-2.5 text-slate-600 dark:text-slate-300">

--- a/frontend/src/utils/sortUsers.test.ts
+++ b/frontend/src/utils/sortUsers.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { __mock } from '../mocks/handlers'
+import App from '../App'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createElement } from 'react'
+
+// TDD: 仕様
+// 1) 参加時間 (joinedAt) 昇順
+// 2) 参加時間が同一なら channelId 昇順（表示は従来どおり displayName）
+
+function namesInTable(): string[] {
+  const rows = document.querySelectorAll('tbody tr')
+  return Array.from(rows).map((tr) => {
+    const nameCell = tr.querySelectorAll('td')[1]
+    return nameCell?.textContent?.trim() || ''
+  })
+}
+
+describe('ユーザー並び順', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('参加時間→チャンネルIDの優先で安定ソートされる', async () => {
+    // displayNameのアルファベット順とchannelId順が逆転するケースを含める
+    __mock.users = [
+      { channelId: 'UC5', displayName: 'Zoe', joinedAt: '2024-01-01T09:00:00.000Z' },
+      { channelId: 'UC4', displayName: 'Amy', joinedAt: '2024-01-01T09:00:00.000Z' },
+      { channelId: 'UC2', displayName: 'Bob', joinedAt: '2024-01-01T10:00:00.000Z' },
+      { channelId: 'UC3', displayName: 'Charlie', joinedAt: '2024-01-01T10:00:00.000Z' },
+      { channelId: 'UC1', displayName: 'Alice', joinedAt: '2024-01-01T10:00:00.000Z' },
+    ]
+
+    render(createElement(App))
+
+    // テーブルが描画され、5名が表示されるまで待機
+    await waitFor(() => expect(namesInTable().length).toBe(5))
+
+    // 期待順: 09:00 グループは channelId 昇順（UC4→UC5 なので Amy→Zoe）
+    //         10:00 グループは UC1→UC2→UC3（Alice→Bob→Charlie）
+    expect(namesInTable()).toEqual(['Amy', 'Zoe', 'Alice', 'Bob', 'Charlie'])
+  })
+})

--- a/frontend/src/utils/sortUsers.ts
+++ b/frontend/src/utils/sortUsers.ts
@@ -1,0 +1,29 @@
+import type { User } from './api'
+
+/**
+ * 並び順: 参加時間(昇順) → channelId(昇順) → displayName(昇順)
+ * joinedAt が欠落している場合は末尾に寄せる。
+ */
+export function sortUsersStable(input: readonly User[]): User[] {
+  const users = [...input]
+  return users.sort((a, b) => {
+    const ta = Date.parse(a.joinedAt || '')
+    const tb = Date.parse(b.joinedAt || '')
+    const aHas = Number.isFinite(ta)
+    const bHas = Number.isFinite(tb)
+    if (aHas && bHas && ta !== tb) return ta - tb
+    if (aHas && !bHas) return -1
+    if (!aHas && bHas) return 1
+
+    // tie: use channelId
+    const idA = (a.channelId || '').toLowerCase()
+    const idB = (b.channelId || '').toLowerCase()
+    if (idA && idB && idA !== idB) return idA.localeCompare(idB, 'en')
+
+    // fallback: displayName
+    const na = (a.displayName || '').toLowerCase()
+    const nb = (b.displayName || '').toLowerCase()
+    return na.localeCompare(nb, 'en')
+  })
+}
+


### PR DESCRIPTION
## Summary
- ユーザーリストの並び順を初回コメント日時→UserChannelIDで安定ソートに変更
- リロード時も順番が変わらない決定的ソートを実装
- テストケースを追加して動作を保証

## Changes
- 新規ファイル: `src/utils/sortUsers.ts` - 安定ソート関数を実装
- 新規ファイル: `src/utils/sortUsers.test.ts` - ソート動作のテストケース
- 修正ファイル: `src/App.jsx` - ユーザーリストにソート機能を適用

## Sort Priority
1. **初回コメント日時（joinedAt）昇順** - 早い時間の人が上に
2. **同じ時間の場合はUserChannelID（channelId）昇順** - 安定した順序
3. **fallbackとしてdisplayName昇順** - 完全な決定的ソート

## Test plan
- [x] ソート関数のユニットテスト実行・通過
- [x] アプリケーションの動作確認
- [x] リロード時の順序安定性確認

🤖 Generated with [Claude Code](https://claude.ai/code)