### PR TITLE
ui: テーブルカラーをより柔らかいグレー系に調整

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -204,22 +204,22 @@ export default function App() {
         {/* Table */}
         <section className="overflow-hidden rounded-lg shadow-subtle ring-1 ring-black/5 dark:ring-white/10 bg-white/80 dark:bg-white/5 backdrop-blur">
           <table className="w-full table-auto text-[14px] leading-7">
-            <thead className="bg-gradient-to-br from-slate-700 to-slate-800 dark:from-slate-200 dark:to-slate-300 text-white dark:text-slate-900">
+            <thead className="bg-gradient-to-br from-slate-400 to-slate-500 dark:from-slate-600 dark:to-slate-700 text-white dark:text-slate-100">
               <tr>
                 <th className="text-left px-4 py-3.5 w-[72px] font-semibold text-[13px] tracking-wide uppercase">#</th>
                 <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">名前</th>
                 <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">参加時間</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-200/80 dark:divide-white/10">
+            <tbody className="divide-y divide-slate-200/60 dark:divide-slate-600/40">
               {users.map((user,i)=> (
-                <tr key={`${user.channelId || user.displayName}`} className={`transition-colors duration-150 hover:bg-slate-100/60 dark:hover:bg-white/8 ${
+                <tr key={`${user.channelId || user.displayName}`} className={`transition-colors duration-150 hover:bg-slate-200/40 dark:hover:bg-slate-700/20 ${
                   i % 2 === 0
-                    ? 'bg-white/90 dark:bg-white/3'
-                    : 'bg-slate-50/80 dark:bg-white/5'
+                    ? 'bg-slate-100/50 dark:bg-slate-800/20'
+                    : 'bg-slate-200/40 dark:bg-slate-700/25'
                 }`}>
                   <td className="px-4 py-3 tabular-nums text-slate-600 dark:text-slate-300 font-medium">{String(i+1).padStart(2,'0')}</td>
-                  <td className="px-4 py-3 truncate-1 text-slate-900 dark:text-slate-100 font-medium" title={user.displayName || user}>{user.displayName || user}</td>
+                  <td className="px-4 py-3 truncate-1 text-slate-800 dark:text-slate-200 font-medium" title={user.displayName || user}>{user.displayName || user}</td>
                   <td className="px-4 py-3 text-slate-600 dark:text-slate-300 font-mono text-[13px]">
                     {user.joinedAt ? new Date(user.joinedAt).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }) : '--:--'}
                   </td>


### PR DESCRIPTION
## 概要
テーブルの色調を「白すぎる」デザインからより柔らかいグレー系に調整しました。

## 変更内容
- **ヘッダーグラデーション**: `slate-700/800` → `slate-400/500` でより薄いグレーに変更
- **交互の行背景**: より控えめなグレーの組み合わせに調整（`slate-100/50`と`slate-200/40`）
- **ホバー効果**: より自然なグレー系に変更
- **ダークモード**: 適切なコントラストを維持したまま調整

## 視覚的改善
- 目に優しい柔らかい色調
- 読みやすさを保ちながら白すぎない仕上がり
- ライト・ダーク両モードでの一貫したUX

🤖 Generated with [Claude Code](https://claude.ai/code)