### PR TITLE
feat: 配信終了検知の改善と自動監視ストップ機能の強化

### DIFF
--- a/backend/internal/adapter/youtube/api.go
+++ b/backend/internal/adapter/youtube/api.go
@@ -95,11 +95,16 @@ func (a *API) ListLiveChatMessages(ctx context.Context, liveChatID string) (item
 	if err != nil {
 		log.Printf("[YOUTUBE_API] API call failed: %v", err)
 
-		// 403エラーやliveChatDisabled等で配信終了を検知
-		if strings.Contains(err.Error(), "forbidden") ||
-			strings.Contains(err.Error(), "liveChatDisabled") ||
-			strings.Contains(err.Error(), "liveChatEnded") {
-			log.Printf("[YOUTUBE_API] Live chat ended or disabled")
+		// より詳細な配信終了検知条件
+		errMsg := strings.ToLower(err.Error())
+		if strings.Contains(errMsg, "forbidden") ||
+			strings.Contains(errMsg, "livechatdisabled") ||
+			strings.Contains(errMsg, "livechatended") ||
+			strings.Contains(errMsg, "livechatnotfound") ||
+			strings.Contains(errMsg, "chatdisabled") ||
+			strings.Contains(errMsg, "livechatnotactive") ||
+			(strings.Contains(errMsg, "notfound") && strings.Contains(errMsg, "livechat")) {
+			log.Printf("[YOUTUBE_API] Live chat ended or disabled - Error: %s", errMsg)
 			return nil, true, nil
 		}
 

--- a/backend/internal/usecase/pull.go
+++ b/backend/internal/usecase/pull.go
@@ -43,9 +43,9 @@ func (uc *Pull) Execute(ctx context.Context) (PullOutput, error) {
 		// ユーザークリア
 		uc.Users.Clear()
 
-		// WAITINGに戻す
+		// WAITINGに戻す（現在時刻を終了時刻として設定）
 		state.Status = domain.StatusWaiting
-		state.EndedAt = state.StartedAt // 簡易的に開始時刻を終了時刻として設定
+		state.EndedAt = uc.Clock.Now()
 		if err := uc.State.Set(ctx, state); err != nil {
 			return PullOutput{}, err
 		}

--- a/backend/internal/usecase/pull_test.go
+++ b/backend/internal/usecase/pull_test.go
@@ -62,9 +62,16 @@ func TestPull_Ended_AutoReset(t *testing.T) {
 	users := memory.NewUserRepo()
 	_ = users.UpsertWithJoinTime("ch1", "Alice", time.Now()) // 事前にユーザーを追加
 	state := memory.NewStateRepo()
-	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "v", LiveChatID: "live:abc"})
+	startedAt := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	_ = state.Set(ctx, domain.LiveState{
+		Status:     domain.StatusActive,
+		VideoID:    "v",
+		LiveChatID: "live:abc",
+		StartedAt:  startedAt,
+	})
 	yt := &fakeYTForPull{items: nil, ended: true}
-	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
+	endedAt := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: endedAt}
 
 	uc := &usecase.Pull{YT: yt, Users: users, State: state, Clock: clock}
 	out, err := uc.Execute(ctx)
@@ -86,5 +93,69 @@ func TestPull_Ended_AutoReset(t *testing.T) {
 	currentState, _ := state.Get(ctx)
 	if currentState.Status != domain.StatusWaiting {
 		t.Errorf("State.Status = %v, want %v", currentState.Status, domain.StatusWaiting)
+	}
+
+	// EndedAt時刻が正確に設定されているか確認
+	if !currentState.EndedAt.Equal(endedAt) {
+		t.Errorf("State.EndedAt = %v, want %v", currentState.EndedAt, endedAt)
+	}
+}
+
+func TestPull_WaitingState_NoOperation(t *testing.T) {
+	ctx := context.Background()
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusWaiting, VideoID: "v", LiveChatID: ""})
+	yt := &fakeYTForPull{items: []port.ChatMessage{{ChannelID: "ch1", DisplayName: "Alice"}}, ended: false}
+	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
+
+	uc := &usecase.Pull{YT: yt, Users: users, State: state, Clock: clock}
+	out, err := uc.Execute(ctx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	// WAITING状態では何も処理されない
+	if out.AddedCount != 0 {
+		t.Errorf("AddedCount = %d, want 0", out.AddedCount)
+	}
+	if out.AutoReset {
+		t.Errorf("AutoReset = true, want false")
+	}
+	if users.Count() != 0 {
+		t.Errorf("Users.Count() = %d, want 0", users.Count())
+	}
+}
+
+func TestPull_MultipleUsers_AddedCorrectly(t *testing.T) {
+	ctx := context.Background()
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "v", LiveChatID: "live:abc"})
+	yt := &fakeYTForPull{
+		items: []port.ChatMessage{
+			{ChannelID: "ch1", DisplayName: "Alice"},
+			{ChannelID: "ch2", DisplayName: "Bob"},
+			{ChannelID: "ch3", DisplayName: "Charlie"},
+		},
+		ended: false,
+	}
+	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
+
+	uc := &usecase.Pull{YT: yt, Users: users, State: state, Clock: clock}
+	out, err := uc.Execute(ctx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	// 複数ユーザーが追加されたか確認
+	if out.AddedCount != 3 {
+		t.Errorf("AddedCount = %d, want 3", out.AddedCount)
+	}
+	if out.AutoReset {
+		t.Errorf("AutoReset = true, want false")
+	}
+	if users.Count() != 3 {
+		t.Errorf("Users.Count() = %d, want 3", users.Count())
 	}
 }


### PR DESCRIPTION
## 概要
YouTube Live Chat モニターの配信終了検知機能を改善し、自動監視ストップ機能を強化しました。

## 主な変更点

### 🔍 配信終了検知の改善
- **より詳細なエラーパターンに対応**:
  - `forbidden`, `livechatdisabled`, `livechatended`
  - `livechatnotfound`, `chatdisabled`, `livechatnotactive`
  - `notfound` & `livechat` の組み合わせ
- **検知精度の向上**: エラーメッセージの大文字小文字を統一

### ⚙️ 自動リセット機能の強化
- **正確な終了時刻記録**: `Clock.Now()` を使用してEndedAt時刻を精密に設定
- **自動ユーザークリア**: 配信終了検知時に即座にユーザーリストをクリア
- **状態管理**: WAITING状態への自動切り替え

### ✅ テストカバレッジの向上
- EndedAt時刻の正確性テスト追加
- WAITING状態での動作確認テスト追加
- 複数ユーザー追加の動作テスト追加
- AutoReset機能の詳細テスト強化

## 期待される効果
- 🎯 **配信終了の自動検知精度向上**: より多くのエラーパターンに対応
- 🔄 **運用の自動化**: 人手によるリセット操作が不要
- 📊 **リソース効率化**: 不要な監視の自動停止でAPI負荷削減
- ⏰ **正確な記録**: 配信終了時刻の精密な記録

## テスト結果
```
=== RUN   TestPull_AddsUsers_NormalFlow
--- PASS: TestPull_AddsUsers_NormalFlow (0.00s)
=== RUN   TestPull_Ended_AutoReset
--- PASS: TestPull_Ended_AutoReset (0.00s)
=== RUN   TestPull_WaitingState_NoOperation
--- PASS: TestPull_WaitingState_NoOperation (0.00s)
=== RUN   TestPull_MultipleUsers_AddedCorrectly
--- PASS: TestPull_MultipleUsers_AddedCorrectly (0.00s)
PASS
```

## 互換性
- 既存APIの動作に影響なし
- 配信終了時の`AutoReset: true`レスポンスは維持
- フロントエンドとの連携は変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)