### PR TITLE
fix: YouTube APIから実際の投稿時刻を取得・使用するように修正

### DIFF
--- a/backend/internal/port/youtube.go
+++ b/backend/internal/port/youtube.go
@@ -1,11 +1,15 @@
 package port
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ChatMessage は YouTube Live Chat のメッセージの最小情報です。
 type ChatMessage struct {
 	ChannelID   string
 	DisplayName string
+	PublishedAt time.Time
 }
 
 // YouTubePort は YouTube API 呼び出しを抽象化します。

--- a/backend/internal/usecase/pull.go
+++ b/backend/internal/usecase/pull.go
@@ -53,11 +53,12 @@ func (uc *Pull) Execute(ctx context.Context) (PullOutput, error) {
 		return PullOutput{AddedCount: 0, AutoReset: true}, nil
 	}
 
-	// ユーザー追加
+	// ユーザー追加 - 実際の投稿時刻を使用
 	addedCount := 0
 	now := uc.Clock.Now()
 	for _, msg := range items {
-		if err := uc.Users.UpsertWithJoinTime(msg.ChannelID, msg.DisplayName, now); err != nil {
+		// YouTube APIから取得した実際の投稿時刻を使用
+		if err := uc.Users.UpsertWithJoinTime(msg.ChannelID, msg.DisplayName, msg.PublishedAt); err != nil {
 			return PullOutput{}, err
 		}
 		addedCount++

--- a/backend/internal/usecase/pull_test.go
+++ b/backend/internal/usecase/pull_test.go
@@ -36,7 +36,7 @@ func TestPull_AddsUsers_NormalFlow(t *testing.T) {
 	users := memory.NewUserRepo()
 	state := memory.NewStateRepo()
 	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "v", LiveChatID: "live:abc"})
-	yt := &fakeYTForPull{items: []port.ChatMessage{{ChannelID: "ch1", DisplayName: "Alice"}}, ended: false}
+	yt := &fakeYTForPull{items: []port.ChatMessage{{ChannelID: "ch1", DisplayName: "Alice", PublishedAt: time.Date(2023, 1, 1, 11, 30, 0, 0, time.UTC)}}, ended: false}
 	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
 
 	uc := &usecase.Pull{YT: yt, Users: users, State: state, Clock: clock}
@@ -78,9 +78,9 @@ func TestPull_MultipleComments_IncrementCount(t *testing.T) {
 	
 	// ch1が2回、ch2が1回コメントするシナリオ
 	yt := &fakeYTForPull{items: []port.ChatMessage{
-		{ChannelID: "ch1", DisplayName: "Alice"},
-		{ChannelID: "ch2", DisplayName: "Bob"},
-		{ChannelID: "ch1", DisplayName: "Alice"},
+		{ChannelID: "ch1", DisplayName: "Alice", PublishedAt: time.Date(2023, 1, 1, 11, 30, 0, 0, time.UTC)},
+		{ChannelID: "ch2", DisplayName: "Bob", PublishedAt: time.Date(2023, 1, 1, 11, 35, 0, 0, time.UTC)},
+		{ChannelID: "ch1", DisplayName: "Alice", PublishedAt: time.Date(2023, 1, 1, 11, 40, 0, 0, time.UTC)},
 	}, ended: false}
 	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
 
@@ -165,7 +165,7 @@ func TestPull_WaitingState_NoOperation(t *testing.T) {
 	users := memory.NewUserRepo()
 	state := memory.NewStateRepo()
 	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusWaiting, VideoID: "v", LiveChatID: ""})
-	yt := &fakeYTForPull{items: []port.ChatMessage{{ChannelID: "ch1", DisplayName: "Alice"}}, ended: false}
+	yt := &fakeYTForPull{items: []port.ChatMessage{{ChannelID: "ch1", DisplayName: "Alice", PublishedAt: time.Date(2023, 1, 1, 11, 30, 0, 0, time.UTC)}}, ended: false}
 	clock := &fakeClock{now: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)}
 
 	uc := &usecase.Pull{YT: yt, Users: users, State: state, Clock: clock}
@@ -193,9 +193,9 @@ func TestPull_MultipleUsers_AddedCorrectly(t *testing.T) {
 	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "v", LiveChatID: "live:abc"})
 	yt := &fakeYTForPull{
 		items: []port.ChatMessage{
-			{ChannelID: "ch1", DisplayName: "Alice"},
-			{ChannelID: "ch2", DisplayName: "Bob"},
-			{ChannelID: "ch3", DisplayName: "Charlie"},
+			{ChannelID: "ch1", DisplayName: "Alice", PublishedAt: time.Date(2023, 1, 1, 11, 30, 0, 0, time.UTC)},
+			{ChannelID: "ch2", DisplayName: "Bob", PublishedAt: time.Date(2023, 1, 1, 11, 35, 0, 0, time.UTC)},
+			{ChannelID: "ch3", DisplayName: "Charlie", PublishedAt: time.Date(2023, 1, 1, 11, 40, 0, 0, time.UTC)},
 		},
 		ended: false,
 	}


### PR DESCRIPTION
## Summary
- YouTube APIから取得したメッセージの実際の投稿時刻（PublishedAt）を使用するように修正
- ChatMessage構造体にPublishedAt時刻フィールドを追加
- Pull usecaseでバックエンドのClock.Now()ではなく、実際のメッセージ投稿時刻を使用
- 関連するテストケースも更新

## 変更内容
- `port.ChatMessage`に`PublishedAt time.Time`フィールドを追加
- YouTube API実装でmessageのpublishedAtを正しくパース
- Pull usecaseでの時刻取得ロジックを修正
- テストコードでのChatMessage作成を更新

## Test plan
- [x] 既存テストケースが全て通ることを確認
- [x] 複数コメント・複数ユーザーのシナリオでも正しく動作することを確認
- [x] 配信終了時の自動リセット機能も正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)