### PR TITLE
feat: UserTableから参加時間列を削除し、初回コメント時間のみに統一

### DIFF
--- a/frontend/src/components/UserTable.tsx
+++ b/frontend/src/components/UserTable.tsx
@@ -41,17 +41,6 @@ const getUserFirstComment = (user: UserData): string => {
   return '--:--'
 }
 
-const getUserJoinedAt = (user: UserData): string => {
-  if (typeof user === 'string') return '--:--'
-  if (user.joinedAt) {
-    return new Date(user.joinedAt).toLocaleTimeString('ja-JP', {
-      hour: '2-digit',
-      minute: '2-digit',
-      timeZone: 'Asia/Tokyo'
-    })
-  }
-  return '--:--'
-}
 
 export function UserTable({ users }: UserTableProps) {
   return (
@@ -63,7 +52,6 @@ export function UserTable({ users }: UserTableProps) {
             <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">名前</th>
             <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">発言数</th>
             <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">初回コメント</th>
-            <th className="text-left px-4 py-3.5 font-semibold text-[13px] tracking-wide uppercase">参加時間</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-200/60 dark:divide-slate-600/40">
@@ -96,9 +84,6 @@ export function UserTable({ users }: UserTableProps) {
                 data-testid={`first-comment-${i}`}
               >
                 {getUserFirstComment(user)}
-              </td>
-              <td className="px-4 py-3 text-slate-600 dark:text-slate-300 font-mono text-[13px]">
-                {getUserJoinedAt(user)}
               </td>
             </tr>
           ))}

--- a/frontend/src/components/__tests__/UserTable.spec.tsx
+++ b/frontend/src/components/__tests__/UserTable.spec.tsx
@@ -26,7 +26,6 @@ describe('UserTable コンポーネント', () => {
     expect(screen.getByText('名前')).toBeInTheDocument()
     expect(screen.getByText('発言数')).toBeInTheDocument()
     expect(screen.getByText('初回コメント')).toBeInTheDocument()
-    expect(screen.getByText('参加時間')).toBeInTheDocument()
   })
 
   test('ユーザー情報が正しく表示される', () => {
@@ -51,14 +50,6 @@ describe('UserTable コンポーネント', () => {
     expect(screen.getByTestId('first-comment-1')).toHaveTextContent('21:32')
   })
 
-  test('参加時間が正しく表示される', () => {
-    render(<UserTable users={mockUsers} />)
-
-    // テストIDは生成されないが、内容で確認
-    const rows = screen.getAllByRole('row')
-    expect(rows[1]).toHaveTextContent('21:00') // 1番目のユーザーの参加時間
-    expect(rows[2]).toHaveTextContent('21:30') // 2番目のユーザーの参加時間
-  })
 
   test('firstCommentedAtがない場合--:--が表示される', () => {
     const usersWithoutFirstComment = [


### PR DESCRIPTION
## Summary
• UserTableコンポーネントから「参加時間」列を削除
• 「初回コメント」列のみを表示する仕様に統一  
• UIが簡潔になり、ユーザーにとってより見やすいテーブルに改善

## 変更内容
• **UserTable.tsx**: 参加時間列とgetUserJoinedAt関数を削除
• **UserTable.spec.tsx**: 参加時間関連のテストケースを削除
• **App.integration.spec.tsx**: 統合テストを初回コメント時間表示に対応

## Test plan
- [x] 全60テストが正常にパス
- [x] テーブルが4列構成（#、名前、発言数、初回コメント）で正しく表示
- [x] 初回コメント時間のフォーマット（HH:mm）が正しく動作
- [x] コメントしていないユーザーは「--:--」で表示

🤖 Generated with [Claude Code](https://claude.ai/code)