### PR TITLE
fix: DockerfileのGoバージョンを修正して本番環境エラーを解決

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.23
 FROM golang:${GO_VERSION}-alpine AS build
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
## Summary
- DockerfileのGoバージョンを存在しない1.24から正しい1.23に修正
- 本番環境で発生していた500エラーの原因を解決

## 問題
本番環境（Cloud Run）で以下のエラーが発生：
- `/pull`エンドポイントで500エラー
- `Failed to pull messages`エラー

## 原因
DockerfileでGo 1.24という存在しないバージョンが指定されていたため、本番環境でビルドが失敗していました。

## 変更内容
- `ARG GO_VERSION=1.24` → `ARG GO_VERSION=1.23`に修正

## テスト計画
- [x] ローカル環境でDockerビルドが成功することを確認
- [ ] 本番環境へデプロイ後、pullエンドポイントが正常動作することを確認

## 関連PR
- #45: 初回コメントタイムスタンプの修正（コード側の修正は完了済み）

🤖 Generated with [Claude Code](https://claude.ai/code)