### PR TITLE
fix: Cloud Runデプロイ失敗の修正

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -20,10 +19,10 @@ import (
 )
 
 func main() {
+	// .envファイルの読み込み（本番環境では存在しない場合があるため、エラーでも続行）
 	err := godotenv.Load(".env")
 	if err != nil {
-		fmt.Printf("can not read env file.: %v", err)
-		return
+		log.Printf("Warning: can not read env file (this is normal in production): %v", err)
 	}
 
 	// 設定の読み込みと検証


### PR DESCRIPTION
## Summary
Cloud Runでのデプロイ失敗を解決するため、.envファイル読み込みエラー時の処理を修正

## 問題
Cloud Runでのデプロイ時に以下のエラーが発生：
```
The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable within the allocated timeout.
```

## 原因
- main.goで`.env`ファイル読み込みに失敗すると`return`で処理が終了
- Cloud Run環境には`.env`ファイルが存在しないため、アプリケーションが起動しない

## 変更内容
- `.env`ファイル読み込みエラーをWarningログに変更し、処理を継続
- 未使用の`fmt`パッケージを削除

## テスト計画
- [x] ローカル環境でのテスト成功確認
- [ ] Cloud Runでのデプロイ成功確認
- [ ] 本番環境での正常動作確認

## 影響範囲
- Cloud Runでのデプロイが成功するように修正
- 本番環境でのアプリケーション起動が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)