### PR TITLE
fix: statusエンドポイントにliveChatIDを追加して500エラーを修正

### DIFF
--- a/backend/internal/adapter/http/handlers.go
+++ b/backend/internal/adapter/http/handlers.go
@@ -40,6 +40,7 @@ func NewRouter(h *Handlers, frontendOrigin string) stdhttp.Handler {
 			"status":       string(out.Status),
 			"count":        out.Count,
 			"videoId":      out.VideoID,
+			"liveChatId":   out.LiveChatID,
 			"startedAt":    out.StartedAt,
 			"endedAt":      out.EndedAt,
 			"lastPulledAt": out.LastPulledAt,

--- a/backend/internal/usecase/status.go
+++ b/backend/internal/usecase/status.go
@@ -12,6 +12,7 @@ type StatusOutput struct {
 	Status       domain.Status
 	Count        int
 	VideoID      string
+	LiveChatID   string
 	StartedAt    time.Time
 	EndedAt      time.Time
 	LastPulledAt time.Time
@@ -36,6 +37,7 @@ func (uc *Status) Execute(ctx context.Context) (StatusOutput, error) {
 		Status:       state.Status,
 		Count:        count,
 		VideoID:      state.VideoID,
+		LiveChatID:   state.LiveChatID,
 		StartedAt:    state.StartedAt,
 		EndedAt:      state.EndedAt,
 		LastPulledAt: state.LastPulledAt,


### PR DESCRIPTION
## Summary
本番環境でのpullエンドポイント500エラーを修正するため、statusエンドポイントにliveChatIDを追加

## 問題
- 本番環境でpullエンドポイントにアクセスすると500エラーが発生
- pullエンドポイントはliveChatIDが必要だが、statusエンドポイントで取得できない
- フロントエンドがstatusからliveChatIDを取得できずにpull処理が失敗

## 原因
- StatusOutputにLiveChatIDフィールドが含まれていない
- statusエンドポイントのレスポンスにliveChatIdが含まれていない
- switch-videoエンドポイントにはliveChatIdが含まれているが、statusには含まれていない

## 変更内容
- StatusOutputにLiveChatIDフィールドを追加
- Status.ExecuteメソッドでLiveChatIDを返すよう修正
- statusエンドポイントのレスポンスに"liveChatId"を追加

## テスト計画
- [x] ローカル環境でのテスト成功確認
- [ ] 本番環境でのstatusエンドポイント確認（liveChatId含む）
- [ ] 本番環境でのpullエンドポイント正常動作確認

## 影響範囲
- statusエンドポイントのレスポンス形式にliveChatIdフィールドが追加
- pullエンドポイントの500エラーが修正される
- フロントエンドでの状態表示とpull処理が正常動作

🤖 Generated with [Claude Code](https://claude.ai/code)