### PR TITLE
fix: 本番環境でYouTube API使用を有効化（GO_ENV=production追加）

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,4 +47,4 @@ jobs:
             --concurrency 80 \
             --min-instances 0 \
             --max-instances 2 \
-            --set-env-vars YT_API_KEY=${{ secrets.YT_API_KEY }},FRONTEND_ORIGIN=${{ secrets.FRONTEND_ORIGIN }},POLL_SEC=${{ secrets.POLL_SEC }}
+            --set-env-vars YT_API_KEY=${{ secrets.YT_API_KEY }},FRONTEND_ORIGIN=${{ secrets.FRONTEND_ORIGIN }},POLL_SEC=${{ secrets.POLL_SEC }},GO_ENV=production


### PR DESCRIPTION
## Summary
本番環境でpullエンドポイントが失敗する根本原因を修正

## 問題
- 本番環境でpullエンドポイントが500エラーで失敗
- ローカル環境では正常動作するが、本番環境でのみ失敗
- statusエンドポイントでliveChatIDはモック値（`live:xxx:chat`）を返している

## 根本原因
- `GO_ENV=production`が本番環境に設定されていない
- YouTube API実装でGO_ENVが未設定の場合はモックAPIを使用する仕様
- 本番環境でもモック値を使ってしまい、実際のYouTube API が呼ばれない
- pullエンドポイントでモックliveChatIDを使ってYouTube API呼び出しが失敗

## 変更内容
- Cloud Runデプロイ時の環境変数に`GO_ENV=production`を追加
- 本番環境で実際のYouTube Data API v3が使用されるように設定

## 影響
- 本番環境で実際のYouTube APIキーを使用
- pullエンドポイントが正常動作
- リアルタイムコメント取得が動作

## テスト計画
- [ ] デプロイ後、本番環境でpullエンドポイントが正常動作することを確認
- [ ] statusエンドポイントで実際のliveChatIDが取得されることを確認
- [ ] YouTube APIからのライブチャットメッセージ取得が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)