### PR TITLE
feat: YouTube Studio URLパターンのサポートを追加

### DIFF
--- a/backend/internal/adapter/http/video_id_extractor.go
+++ b/backend/internal/adapter/http/video_id_extractor.go
@@ -68,6 +68,7 @@ func isYouTubeDomain(host string) bool {
 	ytDomains := []string{
 		"youtube.com",
 		"www.youtube.com",
+		"studio.youtube.com",
 		"youtu.be",
 		"m.youtube.com",
 	}

--- a/backend/internal/adapter/http/video_id_extractor_test.go
+++ b/backend/internal/adapter/http/video_id_extractor_test.go
@@ -18,6 +18,12 @@ func TestExtractVideoID(t *testing.T) {
 			hasError: false,
 		},
 		{
+			name:     "YouTube Studio ライブチャットURL",
+			input:    "https://studio.youtube.com/live_chat?is_popout=1&v=bIRpAmqwbvs",
+			expected: "bIRpAmqwbvs",
+			hasError: false,
+		},
+		{
 			name:     "通常の動画URL",
 			input:    "https://www.youtube.com/watch?v=Qw3tyIFqKrg",
 			expected: "Qw3tyIFqKrg",


### PR DESCRIPTION
## Summary
• YouTube Studio (studio.youtube.com) のライブチャットURLからvideo_idを抽出できるように機能拡張
• TDDアプローチで実装（Red→Green→Refactor）
• 既存のURL処理ロジックへの影響なし

## 対応URL例
```
https://studio.youtube.com/live_chat?is_popout=1&v=bIRpAmqwbvs
```

## Test plan
- [x] YouTube Studio URLパターンのテストケースを追加
- [x] テストが失敗することを確認（Red）
- [x] isYouTubeDomain関数に"studio.youtube.com"ドメインを追加（Green）
- [x] 全てのテストが通ることを確認（Refactor）
- [x] 既存のURLパターンに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)