### PR TITLE
chore(deploy): YT_API_KEY を Secret Manager 参照に変更

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,4 +47,5 @@ jobs:
             --concurrency 80 \
             --min-instances 0 \
             --max-instances 2 \
-            --set-env-vars YT_API_KEY=${{ secrets.YT_API_KEY }},FRONTEND_ORIGIN=${{ secrets.FRONTEND_ORIGIN }},POLL_SEC=${{ secrets.POLL_SEC }}
+            --set-env-vars FRONTEND_ORIGIN=${{ secrets.FRONTEND_ORIGIN }},POLL_SEC=${{ secrets.POLL_SEC }} \
+            --set-secrets YT_API_KEY=yt-api-key:latest


### PR DESCRIPTION
## Summary
- Cloud Run環境変数で平文保持していた `YT_API_KEY` を Secret Manager 参照に変更
- GitHub Actions デプロイ時に `--set-secrets YT_API_KEY=yt-api-key:latest` を使用

## 背景
`gcloud run services describe` で環境変数が閲覧可能だったためキー漏洩リスクあり。Secret Manager移行で読み取り権限を `secretmanager.secretAccessor` ロール持ちに限定。

## 事前対応済み（本番環境）
- Secret Manager API 有効化
- Secret `yt-api-key` 作成（v2が現行、v1は破棄）
- Runtime SA (`203638528729-compute@developer`) と GHA SA (`github-actions@...`) に `secretmanager.secretAccessor` を当該secretスコープで付与
- Cloud Run リビジョン `00031-5xj` でsecret参照に切替、/status 200 確認

## 追加作業（本PRマージ後）
- GitHub Secrets から不要になった `YT_API_KEY` を削除

## Test plan
- [ ] PR merge後、main への push で `deploy-backend.yml` が発火
- [ ] Cloud Run 新リビジョンが secret 参照で起動
- [ ] `/status` 200 応答確認