### PR TITLE
ポーリング間隔を 60s 以上に引き上げ YouTube API quota を保守的に確保

### DIFF
--- a/backend/internal/usecase/pull.go
+++ b/backend/internal/usecase/pull.go
@@ -126,8 +126,8 @@ func (uc *Pull) Execute(ctx context.Context) (PullOutput, error) {
 	}
 
 	// minPollingIntervalMillis はYouTube Data API v3の無料枠制限（10,000 units/day）を考慮した最小ポーリング間隔
-	// 1回のliveChatMessages.list呼び出しは5 unitsを消費するため、15秒間隔で運用することで1日あたり約5,760回（28,800 units）の呼び出しを制限内に抑える
-	const minPollingIntervalMillis = 15000
+	// 1回のliveChatMessages.list呼び出しは5 unitsを消費するため、60秒間隔で運用することで24時間連続稼働でも約1,440回（7,200 units）に収まり、他 API 呼び出し分の余裕も確保する
+	const minPollingIntervalMillis = 60000
 	if pollMs < minPollingIntervalMillis {
 		pollMs = minPollingIntervalMillis
 	}

--- a/backend/internal/usecase/pull_test.go
+++ b/backend/internal/usecase/pull_test.go
@@ -253,29 +253,24 @@ func TestPull_MinimumPollingInterval(t *testing.T) {
 		expectedPollingMillis int64
 	}{
 		{
-			name:                  "APIが5秒を返した場合は15秒に調整",
+			name:                  "APIが5秒を返した場合は60秒に調整",
 			apiPollingMillis:      5000,
-			expectedPollingMillis: 15000,
+			expectedPollingMillis: 60000,
 		},
 		{
-			name:                  "APIが10秒を返した場合は15秒に調整",
-			apiPollingMillis:      10000,
-			expectedPollingMillis: 15000,
-		},
-		{
-			name:                  "APIが15秒を返した場合はそのまま",
-			apiPollingMillis:      15000,
-			expectedPollingMillis: 15000,
-		},
-		{
-			name:                  "APIが20秒を返した場合はそのまま",
-			apiPollingMillis:      20000,
-			expectedPollingMillis: 20000,
-		},
-		{
-			name:                  "APIが30秒を返した場合はそのまま",
+			name:                  "APIが30秒を返した場合は60秒に調整",
 			apiPollingMillis:      30000,
-			expectedPollingMillis: 30000,
+			expectedPollingMillis: 60000,
+		},
+		{
+			name:                  "APIが60秒を返した場合はそのまま",
+			apiPollingMillis:      60000,
+			expectedPollingMillis: 60000,
+		},
+		{
+			name:                  "APIが90秒を返した場合はそのまま",
+			apiPollingMillis:      90000,
+			expectedPollingMillis: 90000,
 		},
 	}
 

--- a/frontend/src/components/CommentTab/CommentControls.tsx
+++ b/frontend/src/components/CommentTab/CommentControls.tsx
@@ -37,8 +37,6 @@ export function CommentControls({
     }
   }
 
-
-
   return (
     <div className="space-y-4">
       {/* キーワード管理 */}
@@ -107,9 +105,9 @@ export function CommentControls({
             className="text-[12px] px-2 py-1 rounded-md bg-white/90 dark:bg-white/5 border border-slate-300/80 dark:border-white/10"
           >
             <option value="0">停止</option>
-            <option value="10">10s</option>
-            <option value="15">15s</option>
-            <option value="30">30s</option>
+            <option value="60">60s</option>
+            <option value="90">90s</option>
+            <option value="120">120s</option>
           </select>
         </div>
         <div className="text-[12px] text-slate-500 dark:text-slate-400">

--- a/frontend/src/components/UserTable.tsx
+++ b/frontend/src/components/UserTable.tsx
@@ -292,10 +292,9 @@ export function UserTable({
                   className="text-[12px] px-2 py-1 rounded-md bg-white/90 dark:bg-white/5 border border-slate-300/80 dark:border-white/10"
                 >
                   <option value="0">停止</option>
-                  <option value="10">10s</option>
-                  <option value="15">15s</option>
-                  <option value="30">30s</option>
                   <option value="60">60s</option>
+                  <option value="90">90s</option>
+                  <option value="120">120s</option>
                 </select>
               </div>
             )}

--- a/frontend/src/hooks/__tests__/useAppState.spec.tsx
+++ b/frontend/src/hooks/__tests__/useAppState.spec.tsx
@@ -56,7 +56,7 @@ describe('useAppState', () => {
       active: false,
       users: [],
       videoId: '',
-      intervalSec: 15,
+      intervalSec: 60,
       lastUpdated: '--:--:--',
       lastFetchTime: '',
       errorMsg: '',
@@ -261,7 +261,7 @@ describe('useAppState', () => {
     const { result } = renderHook(() => useAppState())
 
     // 初期値の確認
-    expect(result.current.state.intervalSec).toBe(15)
+    expect(result.current.state.intervalSec).toBe(60)
 
     // API更新間隔を60秒に変更
     act(() => {

--- a/frontend/src/hooks/useAppState.ts
+++ b/frontend/src/hooks/useAppState.ts
@@ -48,7 +48,7 @@ export function useAppState(addEntry?: AddEntryFn) {
     active: false,
     users: [],
     videoId: localStorage.getItem('videoId') || '',
-    intervalSec: 15,
+    intervalSec: 60,
     lastUpdated: '--:--:--',
     lastFetchTime: '',
     errorMsg: '',


### PR DESCRIPTION
## Summary

YouTube Data API v3 の無料枠 (10,000 units/day) を超過するリスクを下げるため、ポーリング間隔の最低値を 60 秒に引き上げる。

- backend: `minPollingIntervalMillis` を 15,000 → 60,000 に変更 (`pull.go`)
- frontend: 自動更新 default を 15s → 60s、UI selector の選択肢を `60s / 90s / 120s` に変更 (`UserTable.tsx` / `CommentControls.tsx` / `useAppState.ts`)
- 関連 test の expected 値を 60s 基準に更新

## Why

liveChatMessages.list は 1 call あたり 5 units 消費する。15s 間隔 × 24h 稼働で 28,800 units となり、free quota の 2.88 倍に達する。配信時間内 (想定 1 日 2 回 × 3h) であれば 15s でも枠内だが、誤動作で長時間 pull が継続した場合や他 API (search 等) との合算で枠を使い切る懸念が大きい。60s floor なら 24h 連続稼働でも 7,200 units / day で、他 API 呼び出し分の余裕も確保できる。

## Test plan

- [x] backend `go test ./internal/usecase/...` 通過
- [x] frontend `vitest --run` 130 test 通過
- [ ] deploy 後、自動更新間隔 selector が 60s/90s/120s で表示されること
- [ ] 初回ロード時 default が 60s であること