### PR TITLE
feat(backend): サーバー側の配信予約と監視機能を追加

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/youtube"
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/config"
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/monitor"
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
 )
 
@@ -77,23 +78,35 @@ func main() {
 	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, Comments: comments, State: state, Clock: clock, Snap: coord}
 	ucPull := &usecase.Pull{YT: yt, Users: users, Comments: comments, State: state, Clock: clock, Snap: coord}
 	ucReset := &usecase.Reset{Users: users, Comments: comments, State: state, Snap: coord}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
+	ucCancelReserve := &usecase.CancelReserve{State: state, Snap: coord}
 
 	h := &ahttp.Handlers{
-		Status:      ucStatus,
-		SwitchVideo: ucSwitch,
-		Pull:        ucPull,
-		Reset:       ucReset,
-		Users:       users,
-		Comments:    comments,
-		Coord:       coord,
-		ListHistory: listHistory,
-		GetHistory:  getHistory,
+		Status:        ucStatus,
+		SwitchVideo:   ucSwitch,
+		Pull:          ucPull,
+		Reset:         ucReset,
+		Reserve:       ucReserve,
+		CancelReserve: ucCancelReserve,
+		Users:         users,
+		Comments:      comments,
+		Coord:         coord,
+		ListHistory:   listHistory,
+		GetHistory:    getHistory,
 	}
 	srv := &http.Server{Addr: ":" + cfg.Port, Handler: ahttp.NewRouter(h, cfg.FrontendOrigin)}
 
 	// グレースフルシャットダウンのためのコンテキスト設定
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Monitor goroutine: RESERVED 状態を監視して配信開始時に SwitchVideo を自動実行する。
+	// signal.NotifyContext の ctx をそのまま渡すことで、シャットダウン時に自然停止する。
+	mon := monitor.New(ucSwitch, ucPull, state, clock)
+	mon.Interval = monitor.DefaultInterval
+	mon.Buffer = monitor.DefaultBuffer
+	go mon.Run(ctx)
+	log.Printf("Monitor goroutine started (interval=%s, buffer=%s)", monitor.DefaultInterval, monitor.DefaultBuffer)
 
 	// サーバーを別ゴルーチンで起動
 	go func() {

--- a/backend/internal/adapter/http/errors.go
+++ b/backend/internal/adapter/http/errors.go
@@ -76,6 +76,11 @@ func renderBadRequest(w stdhttp.ResponseWriter, r *stdhttp.Request, message stri
 	renderErrorWithCollector(w, r, StatusBadRequest, "bad_request", message, nil)
 }
 
+// renderBadRequestWithCollector はバッドリクエスト用のヘルパー (collector 付き)
+func renderBadRequestWithCollector(w stdhttp.ResponseWriter, r *stdhttp.Request, message string, collector *logging.Collector) {
+	renderErrorWithCollector(w, r, StatusBadRequest, "bad_request", message, collector)
+}
+
 // renderBadGateway はバッドゲートウェイ用のヘルパー
 func renderBadGateway(w stdhttp.ResponseWriter, r *stdhttp.Request, message string) {
 	renderErrorWithCollector(w, r, StatusBadGateway, "bad_gateway", message, nil)
@@ -112,6 +117,10 @@ func httpStatusFor(code domain.APIErrorCode) int {
 		return stdhttp.StatusGone
 	case domain.ErrCodeAuthFailed:
 		return stdhttp.StatusUnauthorized
+	case domain.ErrCodeConflict:
+		return StatusConflict
+	case domain.ErrCodeInvalidArgument:
+		return StatusBadRequest
 	default:
 		return StatusBadGateway
 	}

--- a/backend/internal/adapter/http/handlers.go
+++ b/backend/internal/adapter/http/handlers.go
@@ -18,28 +18,33 @@ import (
 )
 
 type Handlers struct {
-	Status      *usecase.Status
-	SwitchVideo *usecase.SwitchVideo
-	Pull        *usecase.Pull
-	Reset       *usecase.Reset
-	Users       port.UserRepo
-	Comments    port.CommentRepo
-	Coord       snapshot.Coordinator
-	ListHistory *usecase.ListHistorySnapshots
-	GetHistory  *usecase.GetHistorySnapshot
+	Status        *usecase.Status
+	SwitchVideo   *usecase.SwitchVideo
+	Pull          *usecase.Pull
+	Reset         *usecase.Reset
+	Reserve       *usecase.Reserve
+	CancelReserve *usecase.CancelReserve
+	Users         port.UserRepo
+	Comments      port.CommentRepo
+	Coord         snapshot.Coordinator
+	ListHistory   *usecase.ListHistorySnapshots
+	GetHistory    *usecase.GetHistorySnapshot
 }
 
 // StatusResponse represents the response for /status endpoint
 type StatusResponse struct {
-	Status          string      `json:"status"`
-	Count           int         `json:"count"`
-	VideoID         string      `json:"videoId"`
-	LiveChatID      string      `json:"liveChatId"`
-	StartedAt       any         `json:"startedAt"`
-	EndedAt         any         `json:"endedAt"`
-	LastPulledAt    any         `json:"lastPulledAt"`
-	SnapshotSavedAt *time.Time  `json:"snapshotSavedAt,omitempty"`
-	Logs            []LogDetail `json:"logs,omitempty"`
+	Status               string      `json:"status"`
+	Count                int         `json:"count"`
+	VideoID              string      `json:"videoId"`
+	LiveChatID           string      `json:"liveChatId"`
+	StartedAt            any         `json:"startedAt"`
+	EndedAt              any         `json:"endedAt"`
+	LastPulledAt         any         `json:"lastPulledAt"`
+	ReservedAt           any         `json:"reservedAt"`
+	ScheduledStartTime   any         `json:"scheduledStartTime"`
+	AutonomousMonitoring bool        `json:"autonomousMonitoring"`
+	SnapshotSavedAt      *time.Time  `json:"snapshotSavedAt,omitempty"`
+	Logs                 []LogDetail `json:"logs,omitempty"`
 }
 
 // SwitchVideoResponse represents the response for /switch-video endpoint
@@ -69,6 +74,22 @@ type PullResponse struct {
 
 // ResetResponse represents the response for /reset endpoint
 type ResetResponse struct {
+	Status string      `json:"status"`
+	Logs   []LogDetail `json:"logs,omitempty"`
+}
+
+// ReserveResponse represents the response for /reserve endpoint
+type ReserveResponse struct {
+	Status             string      `json:"status"`
+	VideoID            string      `json:"videoId"`
+	LiveChatID         string      `json:"liveChatId,omitempty"`
+	ScheduledStartTime any         `json:"scheduledStartTime"`
+	ReservedAt         any         `json:"reservedAt"`
+	Logs               []LogDetail `json:"logs,omitempty"`
+}
+
+// CancelReserveResponse represents the response for /cancel-reserve endpoint
+type CancelReserveResponse struct {
 	Status string      `json:"status"`
 	Logs   []LogDetail `json:"logs,omitempty"`
 }
@@ -110,14 +131,17 @@ func NewRouter(h *Handlers, frontendOrigin string) stdhttp.Handler {
 
 		log.Printf("[STATUS] Current status: %s, Users: %d", out.Status, out.Count)
 		response := StatusResponse{
-			Status:       string(out.Status),
-			Count:        out.Count,
-			VideoID:      out.VideoID,
-			LiveChatID:   out.LiveChatID,
-			StartedAt:    out.StartedAt,
-			EndedAt:      out.EndedAt,
-			LastPulledAt: out.LastPulledAt,
-			Logs:         collectLogs(collector),
+			Status:               string(out.Status),
+			Count:                out.Count,
+			VideoID:              out.VideoID,
+			LiveChatID:           out.LiveChatID,
+			StartedAt:            out.StartedAt,
+			EndedAt:              out.EndedAt,
+			LastPulledAt:         out.LastPulledAt,
+			ReservedAt:           out.ReservedAt,
+			ScheduledStartTime:   out.ScheduledStartTime,
+			AutonomousMonitoring: out.AutonomousMonitoring,
+			Logs:                 collectLogs(collector),
 		}
 		if h.Coord != nil {
 			if savedAt := h.Coord.LastSavedAt(); !savedAt.IsZero() {
@@ -270,6 +294,49 @@ func NewRouter(h *Handlers, frontendOrigin string) stdhttp.Handler {
 		resp := newHistorySnapshotResponse(out.Snapshot)
 		resp.Logs = collectLogs(collector)
 		render.JSON(w, r, resp)
+	})
+
+	r.Post("/reserve", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		log.Printf("[RESERVE] Processing reserve request")
+		collector := collectorFromRequest(r)
+		var req struct {
+			VideoID string `json:"videoId"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			renderBadRequestWithCollector(w, r, "Invalid JSON", collector)
+			return
+		}
+		out, err := h.Reserve.Execute(r.Context(), usecase.ReserveInput{VideoID: req.VideoID})
+		if err != nil {
+			log.Printf("[RESERVE] Execute error: %v", err)
+			renderUsecaseError(w, r, err, "Failed to reserve: "+err.Error(), collector, StatusInternalServerError, "internal_error")
+			return
+		}
+		response := ReserveResponse{
+			Status:             string(out.State.Status),
+			VideoID:            out.State.VideoID,
+			LiveChatID:         out.State.LiveChatID,
+			ScheduledStartTime: out.State.ScheduledStartTime,
+			ReservedAt:         out.State.ReservedAt,
+			Logs:               collectLogs(collector),
+		}
+		render.JSON(w, r, response)
+	})
+
+	r.Post("/cancel-reserve", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		log.Printf("[CANCEL_RESERVE] Processing cancel-reserve request")
+		collector := collectorFromRequest(r)
+		out, err := h.CancelReserve.Execute(r.Context())
+		if err != nil {
+			log.Printf("[CANCEL_RESERVE] Execute error: %v", err)
+			renderUsecaseError(w, r, err, "Failed to cancel reserve: "+err.Error(), collector, StatusInternalServerError, "internal_error")
+			return
+		}
+		response := CancelReserveResponse{
+			Status: string(out.State.Status),
+			Logs:   collectLogs(collector),
+		}
+		render.JSON(w, r, response)
 	})
 
 	r.Get("/comments", func(w stdhttp.ResponseWriter, r *stdhttp.Request) {

--- a/backend/internal/adapter/http/handlers_integration_test.go
+++ b/backend/internal/adapter/http/handlers_integration_test.go
@@ -1,10 +1,12 @@
 package http_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	stdhttp "net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +20,56 @@ import (
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
 	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
 )
+
+// fakeYTForReserve は /reserve endpoint テスト用の YouTubePort 実装。
+// GetVideoLiveDetails のみ意味のある値を返す。getDetailsErr が非 nil ならそれを返す。
+type fakeYTForReserve struct {
+	isLive             bool
+	scheduledStartTime time.Time
+	getDetailsErr      error
+}
+
+func (f *fakeYTForReserve) GetActiveLiveChatID(_ context.Context, videoID string) (port.VideoMeta, error) {
+	return port.VideoMeta{LiveChatID: "chat-" + videoID}, nil
+}
+func (f *fakeYTForReserve) ListLiveChatMessages(_ context.Context, _ string, _ string) ([]port.ChatMessage, string, int64, int, bool, error) {
+	return nil, "", 0, 0, false, nil
+}
+func (f *fakeYTForReserve) GetChannelDisplayNames(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeYTForReserve) GetChannelHandles(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeYTForReserve) GetVideoLiveDetails(_ context.Context, _ string) (port.VideoLiveDetails, error) {
+	if f.getDetailsErr != nil {
+		return port.VideoLiveDetails{}, f.getDetailsErr
+	}
+	return port.VideoLiveDetails{
+		IsLiveContent:      f.isLive,
+		ScheduledStartTime: f.scheduledStartTime,
+	}, nil
+}
+
+// newTestServerWithReserve は Reserve / CancelReserve を含む Handlers を持つテストサーバーを返す。
+func newTestServerWithReserve(yt port.YouTubePort) *httptest.Server {
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	clock := system.NewSystemClock()
+	coord := &snapshot.NopCoordinator{}
+
+	h := &ahttp.Handlers{
+		Status:        &usecase.Status{Users: users, State: state},
+		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
+		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
+		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
+		Users:         users,
+		Coord:         coord,
+	}
+	return httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
+}
 
 // fakeCoordinator は LastSavedAt を制御できるテスト用 Coordinator 実装です。
 type fakeCoordinator struct {
@@ -418,6 +470,234 @@ func TestRouter_StatusResponseHasNoLogsField(t *testing.T) {
 	// 正常系では logs は omitempty で absent
 	if _, hasLogs := body["logs"]; hasLogs {
 		t.Errorf("logs field must be absent for successful response with empty collector, got body=%v", body)
+	}
+}
+
+// --- /reserve / /cancel-reserve endpoint integration tests ---
+
+// TestReserve_Success: live video を渡して RESERVED 状態になることを確認する。
+func TestReserve_Success(t *testing.T) {
+	scheduled := time.Date(2024, 6, 10, 18, 0, 0, 0, time.UTC)
+	yt := &fakeYTForReserve{isLive: true, scheduledStartTime: scheduled}
+	ts := newTestServerWithReserve(yt)
+	defer ts.Close()
+
+	body := strings.NewReader(`{"videoId":"VID123"}`)
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/reserve", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "RESERVED" {
+		t.Errorf("status = %v, want RESERVED", resp["status"])
+	}
+	if resp["videoId"] != "VID123" {
+		t.Errorf("videoId = %v, want VID123", resp["videoId"])
+	}
+	if _, ok := resp["scheduledStartTime"]; !ok {
+		t.Error("scheduledStartTime field missing")
+	}
+}
+
+// TestReserve_EmptyVideoID: videoId 空は 400 を返す。
+func TestReserve_EmptyVideoID(t *testing.T) {
+	yt := &fakeYTForReserve{isLive: true}
+	ts := newTestServerWithReserve(yt)
+	defer ts.Close()
+
+	body := bytes.NewReader([]byte(`{"videoId":""}`))
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/reserve", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", res.StatusCode)
+	}
+}
+
+// TestReserve_ConflictWhenActive: ACTIVE 状態での Reserve は 409 を返す。
+func TestReserve_ConflictWhenActive(t *testing.T) {
+	yt := &fakeYTForReserve{isLive: true}
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	clock := system.NewSystemClock()
+	coord := &snapshot.NopCoordinator{}
+
+	// 事前に ACTIVE 状態を作る
+	_ = state.Set(context.Background(), domain.LiveState{Status: domain.StatusActive, VideoID: "existing"})
+
+	h := &ahttp.Handlers{
+		Status:        &usecase.Status{Users: users, State: state},
+		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
+		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
+		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
+		Users:         users,
+		Coord:         coord,
+	}
+	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
+	defer ts.Close()
+
+	body := strings.NewReader(`{"videoId":"VID999"}`)
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/reserve", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusConflict {
+		t.Fatalf("status = %d, want 409", res.StatusCode)
+	}
+}
+
+// TestReserve_VideoNotFound: 存在しない videoId は 404 を返す (httpStatusFor 経由)。
+func TestReserve_VideoNotFound(t *testing.T) {
+	yt := &fakeYTForReserve{
+		getDetailsErr: &domain.APIError{Code: domain.ErrCodeVideoNotFound, Message: "video not found"},
+	}
+	ts := newTestServerWithReserve(yt)
+	defer ts.Close()
+
+	body := strings.NewReader(`{"videoId":"UNKNOWN"}`)
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/reserve", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusNotFound {
+		t.Fatalf("status = %d, want 404", res.StatusCode)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["code"] != string(domain.ErrCodeVideoNotFound) {
+		t.Errorf("code = %v, want %s", resp["code"], domain.ErrCodeVideoNotFound)
+	}
+}
+
+// TestReserve_NotLiveContent: live 配信でない videoId は 400 を返す。
+func TestReserve_NotLiveContent(t *testing.T) {
+	yt := &fakeYTForReserve{isLive: false}
+	ts := newTestServerWithReserve(yt)
+	defer ts.Close()
+
+	body := strings.NewReader(`{"videoId":"NORMALVIDEO"}`)
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/reserve", body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", res.StatusCode)
+	}
+}
+
+// TestCancelReserve_ConflictWhenActive: ACTIVE 状態での cancel-reserve は 409 を返す
+// (現セッション保護のためシンメトリックに拒否する設計)。
+func TestCancelReserve_ConflictWhenActive(t *testing.T) {
+	yt := &fakeYTForReserve{isLive: true}
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	clock := system.NewSystemClock()
+	coord := &snapshot.NopCoordinator{}
+
+	_ = state.Set(context.Background(), domain.LiveState{Status: domain.StatusActive, VideoID: "existing"})
+
+	h := &ahttp.Handlers{
+		Status:        &usecase.Status{Users: users, State: state},
+		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
+		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
+		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
+		Users:         users,
+		Coord:         coord,
+	}
+	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
+	defer ts.Close()
+
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/cancel-reserve", nil)
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cancel-reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusConflict {
+		t.Fatalf("status = %d, want 409", res.StatusCode)
+	}
+}
+
+// TestCancelReserve_Success: RESERVED 状態から cancel-reserve すると WAITING になる。
+func TestCancelReserve_Success(t *testing.T) {
+	yt := &fakeYTForReserve{isLive: true}
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	clock := system.NewSystemClock()
+	coord := &snapshot.NopCoordinator{}
+
+	// 事前に RESERVED 状態を作る
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status:  domain.StatusReserved,
+		VideoID: "VID123",
+	})
+
+	h := &ahttp.Handlers{
+		Status:        &usecase.Status{Users: users, State: state},
+		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
+		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
+		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
+		Users:         users,
+		Coord:         coord,
+	}
+	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
+	defer ts.Close()
+
+	req, _ := stdhttp.NewRequest(stdhttp.MethodPost, ts.URL+"/cancel-reserve", nil)
+	res, err := stdhttp.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /cancel-reserve: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "WAITING" {
+		t.Errorf("status = %v, want WAITING", resp["status"])
 	}
 }
 

--- a/backend/internal/adapter/http/handlers_video_url_test.go
+++ b/backend/internal/adapter/http/handlers_video_url_test.go
@@ -31,6 +31,9 @@ func (f *fakeYTForURL) GetChannelDisplayNames(ctx context.Context, channelIDs []
 func (f *fakeYTForURL) GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error) {
 	return nil, nil
 }
+func (f *fakeYTForURL) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	return port.VideoLiveDetails{}, nil
+}
 
 type fakeClockForURL struct{}
 

--- a/backend/internal/adapter/http/status.go
+++ b/backend/internal/adapter/http/status.go
@@ -6,6 +6,7 @@ import stdhttp "net/http"
 const (
 	StatusNoContent           = stdhttp.StatusNoContent           // 204
 	StatusBadRequest          = stdhttp.StatusBadRequest          // 400
+	StatusConflict            = stdhttp.StatusConflict            // 409
 	StatusInternalServerError = stdhttp.StatusInternalServerError // 500
 	StatusBadGateway          = stdhttp.StatusBadGateway          // 502
 )

--- a/backend/internal/adapter/youtube/api.go
+++ b/backend/internal/adapter/youtube/api.go
@@ -38,10 +38,34 @@ var reasonToCode = map[string]domain.APIErrorCode{
 	"liveChatEnded":         domain.ErrCodeLiveChatEnded,
 	"liveChatDisabled":      domain.ErrCodeLiveChatEnded,
 	"liveChatNotActive":     domain.ErrCodeLiveChatEnded,
+	// API key 不正は HTTP 400 で返ることが手動 e2e で観測済 (reason は大文字)
+	"API_KEY_INVALID": domain.ErrCodeAuthFailed,
+}
+
+// extractReason は googleapi.Error から reason を抽出する。
+// Details (google.rpc.ErrorInfo) を優先。Errors[0] は generic な "badRequest" のみで
+// 具体 reason は Details に入るケースが現代 SDK では多い (例: API_KEY_INVALID)。
+func extractReason(gErr *googleapi.Error) string {
+	for _, d := range gErr.Details {
+		m, ok := d.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := m["@type"].(string); !strings.Contains(t, "ErrorInfo") {
+			continue
+		}
+		if r, ok := m["reason"].(string); ok && r != "" {
+			return r
+		}
+	}
+	if len(gErr.Errors) > 0 {
+		return gErr.Errors[0].Reason
+	}
+	return ""
 }
 
 // classifyAPIError は googleapi.Error を domain.APIError に変換する。
-// HTTP status + Errors[0].Reason に基づいて分類し、既存の logging.Log 呼出は維持する。
+// HTTP status + reason (旧 Errors[0] / 新 Details[].ErrorInfo) に基づいて分類する。
 // 分類できない場合は元のエラーをそのまま返す。
 func classifyAPIError(err error) error {
 	if err == nil {
@@ -53,12 +77,10 @@ func classifyAPIError(err error) error {
 		return err
 	}
 
+	reason := extractReason(gErr)
+
 	// 401/403 で reason 不明な場合は auth_failed にフォールバック
 	if gErr.Code == 401 || gErr.Code == 403 {
-		reason := ""
-		if len(gErr.Errors) > 0 {
-			reason = gErr.Errors[0].Reason
-		}
 		if code, ok := reasonToCode[reason]; ok {
 			return &domain.APIError{Code: code, Message: gErr.Message, Wrapped: err}
 		}
@@ -66,10 +88,6 @@ func classifyAPIError(err error) error {
 	}
 
 	// reason マップで変換を試みる
-	reason := ""
-	if len(gErr.Errors) > 0 {
-		reason = gErr.Errors[0].Reason
-	}
 	if code, ok := reasonToCode[reason]; ok {
 		return &domain.APIError{Code: code, Message: gErr.Message, Wrapped: err}
 	}
@@ -141,40 +159,47 @@ func isTransientError(err error) bool {
 	return false
 }
 
-func (a *API) GetActiveLiveChatID(ctx context.Context, videoID string) (port.VideoMeta, error) {
-	log.Printf("[YOUTUBE_API] GetActiveLiveChatID called with videoID: %s", videoID)
-
+// fetchVideo は videos.list を共通呼び出しする。
+// videoID 不在 / API key 不在 / 動画未取得は domain error / generic error で返す。
+func (a *API) fetchVideo(ctx context.Context, videoID string, parts []string) (*youtube.Video, error) {
 	if a.APIKey == "" {
 		log.Printf("[YOUTUBE_API] Error: API key is empty")
-		return port.VideoMeta{}, errors.New("youtube api key is required")
+		return nil, errors.New("youtube api key is required")
 	}
 
 	if videoID == "" {
 		log.Printf("[YOUTUBE_API] Error: videoID is empty")
-		return port.VideoMeta{}, errors.New("video ID is required")
+		return nil, errors.New("video ID is required")
 	}
 
-	// YouTube Data API v3を使用して動画情報を取得
 	service, err := youtube.NewService(ctx, option.WithAPIKey(a.APIKey))
 	if err != nil {
 		log.Printf("[YOUTUBE_API] Failed to create YouTube service: %v", err)
-		return port.VideoMeta{}, err
+		return nil, err
 	}
 
-	// snippet を追加して title / channelTitle を同一 call で取得する
-	call := service.Videos.List([]string{"liveStreamingDetails", "snippet"}).Id(videoID)
-	response, err := call.Do()
+	response, err := service.Videos.List(parts).Id(videoID).Do()
 	if err != nil {
 		log.Printf("[YOUTUBE_API] Failed to get video details: %v", err)
-		return port.VideoMeta{}, classifyAPIError(err)
+		return nil, classifyAPIError(err)
 	}
 
 	if len(response.Items) == 0 {
 		log.Printf("[YOUTUBE_API] Video not found: %s", videoID)
-		return port.VideoMeta{}, &domain.APIError{Code: domain.ErrCodeVideoNotFound, Message: "video not found"}
+		return nil, &domain.APIError{Code: domain.ErrCodeVideoNotFound, Message: "video not found"}
 	}
 
-	video := response.Items[0]
+	return response.Items[0], nil
+}
+
+func (a *API) GetActiveLiveChatID(ctx context.Context, videoID string) (port.VideoMeta, error) {
+	log.Printf("[YOUTUBE_API] GetActiveLiveChatID called with videoID: %s", videoID)
+
+	video, err := a.fetchVideo(ctx, videoID, []string{"liveStreamingDetails", "snippet"})
+	if err != nil {
+		return port.VideoMeta{}, err
+	}
+
 	if video.LiveStreamingDetails == nil {
 		log.Printf("[YOUTUBE_API] Video is not a live stream: %s", videoID)
 		return port.VideoMeta{}, &domain.APIError{Code: domain.ErrCodeVideoNotFound, Message: "video is not a live stream"}
@@ -410,4 +435,32 @@ func (a *API) GetChannelHandles(ctx context.Context, channelIDs []string) (map[s
 
 	logging.Log(ctx, "info", "YOUTUBE_API", "Resolved %d/%d channel handles (cache size: %d)", len(result), len(channelIDs), len(a.channelHandleCache))
 	return result, nil
+}
+
+// GetVideoLiveDetails は指定 videoID の liveStreamingDetails を取得します。
+// activeLiveChatId が空でもエラーにせず返します (予約監視用)。
+func (a *API) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	video, err := a.fetchVideo(ctx, videoID, []string{"liveStreamingDetails", "snippet"})
+	if err != nil {
+		return port.VideoLiveDetails{}, err
+	}
+
+	details := port.VideoLiveDetails{
+		IsLiveContent: video.LiveStreamingDetails != nil,
+	}
+	if video.Snippet != nil {
+		details.Title = video.Snippet.Title
+		details.ChannelTitle = video.Snippet.ChannelTitle
+	}
+	if video.LiveStreamingDetails != nil {
+		details.LiveChatID = video.LiveStreamingDetails.ActiveLiveChatId
+		if s := video.LiveStreamingDetails.ScheduledStartTime; s != "" {
+			if t, perr := time.Parse(time.RFC3339, s); perr == nil {
+				details.ScheduledStartTime = t
+			} else {
+				logging.Log(ctx, "warn", "YOUTUBE_API", "Failed to parse scheduledStartTime %q for video %s: %v", s, videoID, perr)
+			}
+		}
+	}
+	return details, nil
 }

--- a/backend/internal/adapter/youtube/api_test.go
+++ b/backend/internal/adapter/youtube/api_test.go
@@ -603,6 +603,48 @@ func TestClassifyAPIError(t *testing.T) {
 			wantCode: domain.ErrCodeRateLimited,
 		},
 		{
+			name: "400 API_KEY_INVALID (旧 Errors 形式) → ErrCodeAuthFailed",
+			err: &googleapi.Error{
+				Code:    400,
+				Message: "API key not valid. Please pass a valid API key.",
+				Errors:  []googleapi.ErrorItem{{Reason: "API_KEY_INVALID"}},
+			},
+			wantCode: domain.ErrCodeAuthFailed,
+		},
+		{
+			name: "400 API_KEY_INVALID (新 Details 形式) → ErrCodeAuthFailed",
+			err: &googleapi.Error{
+				Code:    400,
+				Message: "API key not valid. Please pass a valid API key.",
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+						"reason": "API_KEY_INVALID",
+						"domain": "googleapis.com",
+					},
+				},
+			},
+			wantCode: domain.ErrCodeAuthFailed,
+		},
+		{
+			// 現代の Google API は Errors[0] に generic な "badRequest" を、Details に具体 reason を入れる。
+			// Details 優先 (現実の e2e で観測されたケース)。
+			name: "400 Details 優先 (Errors[0]=badRequest, Details=API_KEY_INVALID) → ErrCodeAuthFailed",
+			err: &googleapi.Error{
+				Code:    400,
+				Message: "API key not valid. Please pass a valid API key.",
+				Errors:  []googleapi.ErrorItem{{Reason: "badRequest"}},
+				Details: []interface{}{
+					map[string]interface{}{
+						"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+						"reason": "API_KEY_INVALID",
+						"domain": "googleapis.com",
+					},
+				},
+			},
+			wantCode: domain.ErrCodeAuthFailed,
+		},
+		{
 			name: "500 は分類せずそのまま",
 			err: &googleapi.Error{
 				Code:    500,

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -12,11 +12,13 @@ var ErrNotFound = errors.New("not found")
 type APIErrorCode string
 
 const (
-	ErrCodeQuotaExceeded APIErrorCode = "quota_exceeded"
-	ErrCodeVideoNotFound APIErrorCode = "video_not_found"
-	ErrCodeLiveChatEnded APIErrorCode = "live_chat_ended"
-	ErrCodeAuthFailed    APIErrorCode = "auth_failed"
-	ErrCodeRateLimited   APIErrorCode = "rate_limited"
+	ErrCodeQuotaExceeded   APIErrorCode = "quota_exceeded"
+	ErrCodeVideoNotFound   APIErrorCode = "video_not_found"
+	ErrCodeLiveChatEnded   APIErrorCode = "live_chat_ended"
+	ErrCodeAuthFailed      APIErrorCode = "auth_failed"
+	ErrCodeRateLimited     APIErrorCode = "rate_limited"
+	ErrCodeConflict        APIErrorCode = "conflict"         // 現 state と矛盾する操作 (例: ACTIVE 中の Reserve)
+	ErrCodeInvalidArgument APIErrorCode = "invalid_argument" // 入力不正 (例: 非 live video の Reserve)
 )
 
 // APIError は YouTube API エラーを機械可読コードとともに保持する。

--- a/backend/internal/domain/live.go
+++ b/backend/internal/domain/live.go
@@ -6,19 +6,23 @@ import "time"
 type Status string
 
 const (
-	StatusWaiting Status = "WAITING"
-	StatusActive  Status = "ACTIVE"
+	StatusWaiting  Status = "WAITING"
+	StatusActive   Status = "ACTIVE"
+	StatusReserved Status = "RESERVED"
 )
 
 // LiveState は現在の配信に関する状態を保持します。
 type LiveState struct {
-    Status       Status
-    VideoID      string
-    LiveChatID   string
-    StartedAt    time.Time
-    EndedAt      time.Time
-    LastPulledAt time.Time
-    NextPageToken string
+	Status               Status
+	VideoID              string
+	LiveChatID           string
+	StartedAt            time.Time
+	EndedAt              time.Time
+	LastPulledAt         time.Time
+	NextPageToken        string
+	AutonomousMonitoring bool      // 予約経由 ACTIVE 中はサーバー側で pull する
+	ReservedAt           time.Time // 予約を受け付けた時刻
+	ScheduledStartTime   time.Time // YouTube が返す配信予定開始時刻
 }
 
 // User represents a user with join time information

--- a/backend/internal/port/youtube.go
+++ b/backend/internal/port/youtube.go
@@ -21,6 +21,15 @@ type VideoMeta struct {
 	ChannelTitle string
 }
 
+// VideoLiveDetails は予約監視に必要な liveStreamingDetails の情報です。
+type VideoLiveDetails struct {
+	LiveChatID         string // activeLiveChatId (チャット未開なら空)
+	Title              string
+	ChannelTitle       string
+	ScheduledStartTime time.Time // liveStreamingDetails.scheduledStartTime (未指定なら zero)
+	IsLiveContent      bool      // liveStreamingDetails != nil なら true
+}
+
 // YouTubePort は YouTube API 呼び出しを抽象化します。
 type YouTubePort interface {
 	// 指定 videoID の activeLiveChatId と動画メタデータを取得します。
@@ -33,4 +42,6 @@ type YouTubePort interface {
 	// チャンネルIDからハンドル（@username, snippet.customUrl）を一括取得します。
 	// ハンドルが存在しないチャンネルはマップに含まれません。
 	GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error)
+	// 指定 videoID の liveStreamingDetails を取得します。activeLiveChatId 空でもエラーにせず返します (予約用)。
+	GetVideoLiveDetails(ctx context.Context, videoID string) (VideoLiveDetails, error)
 }

--- a/backend/internal/usecase/cancel_reserve.go
+++ b/backend/internal/usecase/cancel_reserve.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/logging"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
+)
+
+type CancelReserveOutput struct {
+	State domain.LiveState
+}
+
+type CancelReserve struct {
+	State port.StateRepo
+	Snap  snapshot.Coordinator
+}
+
+// Execute: RESERVED/WAITING を WAITING に正規化 (冪等)。
+// ACTIVE 中は 409 Conflict で拒否 — Reserve とシンメトリックに現セッションを守る。
+// users/comments は触らない (Reserve では users 未変更のため)。
+func (uc *CancelReserve) Execute(ctx context.Context) (CancelReserveOutput, error) {
+	cur, err := uc.State.Get(ctx)
+	if err != nil {
+		return CancelReserveOutput{}, fmt.Errorf("state_get: %w", err)
+	}
+	// ACTIVE 中のキャンセルは state 破壊につながるため拒否する
+	if cur.Status == domain.StatusActive {
+		return CancelReserveOutput{}, &domain.APIError{Code: domain.ErrCodeConflict, Message: "stream is currently active, reset first"}
+	}
+
+	newState := domain.LiveState{Status: domain.StatusWaiting}
+	if err := uc.State.Set(ctx, newState); err != nil {
+		return CancelReserveOutput{}, fmt.Errorf("state_set: %w", err)
+	}
+
+	uc.Snap.MarkDirty()
+	if err := uc.Snap.Flush(ctx); err != nil {
+		logging.Log(ctx, "warn", "SNAPSHOT", "cancel_reserve: snapshot flush failed: %v", err)
+	}
+
+	return CancelReserveOutput{State: newState}, nil
+}

--- a/backend/internal/usecase/cancel_reserve_test.go
+++ b/backend/internal/usecase/cancel_reserve_test.go
@@ -1,0 +1,88 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/memory"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
+)
+
+func TestCancelReserve_Reserved_SetsWaiting(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{
+		Status:               domain.StatusReserved,
+		VideoID:              "vid-reserved",
+		AutonomousMonitoring: true,
+	})
+
+	uc := &usecase.CancelReserve{State: state, Snap: &snapshot.NopCoordinator{}}
+
+	out, err := uc.Execute(ctx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if out.State.Status != domain.StatusWaiting {
+		t.Errorf("Status = %v, want %v", out.State.Status, domain.StatusWaiting)
+	}
+	// 予約 field がゼロになっているか確認
+	if out.State.VideoID != "" {
+		t.Errorf("VideoID = %v, want empty", out.State.VideoID)
+	}
+	if out.State.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = true, want false")
+	}
+
+	persisted, _ := state.Get(ctx)
+	if persisted.Status != domain.StatusWaiting {
+		t.Errorf("persisted Status = %v, want %v", persisted.Status, domain.StatusWaiting)
+	}
+}
+
+func TestCancelReserve_Waiting_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	// 既に WAITING — 冪等性確認
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusWaiting})
+
+	uc := &usecase.CancelReserve{State: state, Snap: &snapshot.NopCoordinator{}}
+
+	out, err := uc.Execute(ctx)
+	if err != nil {
+		t.Fatalf("Execute failed on WAITING state: %v", err)
+	}
+	if out.State.Status != domain.StatusWaiting {
+		t.Errorf("Status = %v, want %v", out.State.Status, domain.StatusWaiting)
+	}
+}
+
+// TestCancelReserve_Active_ReturnsConflict: ACTIVE 中のキャンセルは 409 Conflict。
+// Reserve とシンメトリックに現セッションのデータ破壊を防ぐ。
+// ACTIVE 停止は /reset エンドポイントが担う設計。
+func TestCancelReserve_Active_ReturnsConflict(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "live-now"})
+
+	uc := &usecase.CancelReserve{State: state, Snap: &snapshot.NopCoordinator{}}
+
+	_, err := uc.Execute(ctx)
+	if err == nil {
+		t.Fatal("Execute should return error on ACTIVE status")
+	}
+	var apiErr *domain.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *domain.APIError", err)
+	}
+	if apiErr.Code != domain.ErrCodeConflict {
+		t.Errorf("Code = %v, want %v", apiErr.Code, domain.ErrCodeConflict)
+	}
+}

--- a/backend/internal/usecase/monitor/monitor.go
+++ b/backend/internal/usecase/monitor/monitor.go
@@ -1,0 +1,150 @@
+// Package monitor は配信開始を待ち受ける background goroutine を提供する。
+// RESERVED → SwitchVideo 呼出、ACTIVE+AutonomousMonitoring=true → Pull 呼出 を 60s tick で実行する。
+package monitor
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/logging"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+)
+
+const (
+	DefaultInterval = 60 * time.Second
+	DefaultBuffer   = 5 * time.Minute
+)
+
+// switcher は SwitchVideo usecase の依存を抽象化する (test fake 注入用)。
+type switcher interface {
+	Execute(ctx context.Context, in usecase.SwitchVideoInput) (usecase.SwitchVideoOutput, error)
+}
+
+// puller は Pull usecase の依存を抽象化する (test fake 注入用)。
+type puller interface {
+	Execute(ctx context.Context) (usecase.PullOutput, error)
+}
+
+// Monitor は配信開始を待ち受けて SwitchVideo / Pull を自動呼出しする。
+type Monitor struct {
+	SwitchVideo switcher
+	Pull        puller
+	State       port.StateRepo
+	Clock       port.Clock
+	Interval    time.Duration // 0 なら DefaultInterval
+	Buffer      time.Duration // 0 なら DefaultBuffer
+
+	// TickC を inject すると Interval 無視で外部 channel を使う (test 用)。
+	TickC <-chan time.Time
+}
+
+// New は *usecase.SwitchVideo / *usecase.Pull を受け取って Monitor を返す。
+// production での convenience constructor。
+func New(
+	sv *usecase.SwitchVideo,
+	pl *usecase.Pull,
+	state port.StateRepo,
+	clock port.Clock,
+) *Monitor {
+	return &Monitor{
+		SwitchVideo: sv,
+		Pull:        pl,
+		State:       state,
+		Clock:       clock,
+	}
+}
+
+// Run は ctx.Done まで tick loop を回す。
+// RESERVED + ScheduledStartTime - Buffer が未来なら最初に sleep してから tick 開始する。
+func (m *Monitor) Run(ctx context.Context) {
+	interval := m.Interval
+	if interval == 0 {
+		interval = DefaultInterval
+	}
+	buffer := m.Buffer
+	if buffer == 0 {
+		buffer = DefaultBuffer
+	}
+
+	// 初期 sleep: RESERVED + scheduledStartTime - buffer が未来なら待つ (API quota 節約)
+	m.waitUntilScheduled(ctx, buffer)
+	if ctx.Err() != nil {
+		return
+	}
+
+	tickC := m.TickC
+	var ticker *time.Ticker
+	if tickC == nil {
+		ticker = time.NewTicker(interval)
+		defer ticker.Stop()
+		tickC = ticker.C
+	}
+
+	// sleep 完了直後に即実行 (体感応答を良くする)
+	m.process(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tickC:
+			m.process(ctx)
+		}
+	}
+}
+
+// waitUntilScheduled は RESERVED かつ scheduledStartTime - buffer が未来なら sleep する。
+func (m *Monitor) waitUntilScheduled(ctx context.Context, buffer time.Duration) {
+	st, err := m.State.Get(ctx)
+	if err != nil {
+		logging.Log(ctx, "warn", "MONITOR", "state_get on init failed: %v", err)
+		return
+	}
+	if st.Status != domain.StatusReserved || st.ScheduledStartTime.IsZero() {
+		return
+	}
+	wakeAt := st.ScheduledStartTime.Add(-buffer)
+	wait := wakeAt.Sub(m.Clock.Now())
+	if wait <= 0 {
+		return
+	}
+	logging.Log(ctx, "info", "MONITOR", "sleeping until %s (buffer=%s) before tick start", wakeAt.Format(time.RFC3339), buffer)
+	select {
+	case <-ctx.Done():
+	case <-time.After(wait):
+	}
+}
+
+// process は State を再評価して RESERVED / ACTIVE+AM の場合に適切な usecase を呼ぶ。
+// tick ごとに毎回 State.Get することで Reserve / Cancel / Reset 等の動的変化に追従する。
+func (m *Monitor) process(ctx context.Context) {
+	st, err := m.State.Get(ctx)
+	if err != nil {
+		logging.Log(ctx, "warn", "MONITOR", "state_get failed: %v", err)
+		return
+	}
+
+	switch {
+	case st.Status == domain.StatusReserved:
+		logging.Log(ctx, "info", "MONITOR", "tick: RESERVED → SwitchVideo (videoId=%s)", st.VideoID)
+		_, err := m.SwitchVideo.Execute(ctx, usecase.SwitchVideoInput{VideoID: st.VideoID})
+		if err != nil {
+			// 配信未開放は期待される失敗 (info)、それ以外は warn
+			var apiErr *domain.APIError
+			if errors.As(err, &apiErr) && apiErr.Code == domain.ErrCodeLiveChatEnded {
+				logging.Log(ctx, "info", "MONITOR", "switch_video: chat not yet open: %v", err)
+			} else {
+				logging.Log(ctx, "warn", "MONITOR", "switch_video failed: %v", err)
+			}
+		}
+	case st.Status == domain.StatusActive && st.AutonomousMonitoring:
+		if _, err := m.Pull.Execute(ctx); err != nil {
+			logging.Log(ctx, "warn", "MONITOR", "pull failed: %v", err)
+		}
+	default:
+		// WAITING / ACTIVE+AM=false → no-op
+	}
+}

--- a/backend/internal/usecase/monitor/monitor_test.go
+++ b/backend/internal/usecase/monitor/monitor_test.go
@@ -1,0 +1,304 @@
+package monitor_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/memory"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/monitor"
+)
+
+// --- fake implementations ---
+
+type fakeSwitcher struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (f *fakeSwitcher) Execute(_ context.Context, _ usecase.SwitchVideoInput) (usecase.SwitchVideoOutput, error) {
+	f.calls.Add(1)
+	return usecase.SwitchVideoOutput{}, f.err
+}
+
+type fakePuller struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (f *fakePuller) Execute(_ context.Context) (usecase.PullOutput, error) {
+	f.calls.Add(1)
+	return usecase.PullOutput{}, f.err
+}
+
+// fixedClock は Clock interface の固定時刻実装。
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+// buildMonitor は tick channel inject 済みの Monitor を生成するヘルパー。
+func buildMonitor(sw *fakeSwitcher, pl *fakePuller, state *memory.StateRepo, tickC <-chan time.Time) *monitor.Monitor {
+	return &monitor.Monitor{
+		SwitchVideo: sw,
+		Pull:        pl,
+		State:       state,
+		Clock:       fixedClock{t: time.Now()},
+		TickC:       tickC,
+	}
+}
+
+// --- tests ---
+
+// TestMonitor_Reserved_CallsSwitchVideo: RESERVED 状態で tick 1 回 → SwitchVideo が 1 回呼ばれる。
+func TestMonitor_Reserved_CallsSwitchVideo(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status:  domain.StatusReserved,
+		VideoID: "vid001",
+	})
+
+	tickC := make(chan time.Time, 1)
+	m := buildMonitor(sw, pl, state, tickC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	// Run は起動直後に process を 1 回実行する (initial call)
+	// tickC からの tick を送って 2 回目を駆動してからキャンセル
+	tickC <- time.Now()
+	// キャンセル前に goroutine が process を処理できるよう少し待つ
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	// initial process (1) + tick driven process (1) = 2 回
+	if got := sw.calls.Load(); got < 1 {
+		t.Errorf("SwitchVideo.Execute call count = %d, want >= 1", got)
+	}
+	if pl.calls.Load() != 0 {
+		t.Errorf("Pull.Execute should not be called, got %d", pl.calls.Load())
+	}
+}
+
+// TestMonitor_ActiveAM_CallsPull: ACTIVE+AutonomousMonitoring=true で tick → Pull が呼ばれる。
+func TestMonitor_ActiveAM_CallsPull(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status:               domain.StatusActive,
+		VideoID:              "vid002",
+		AutonomousMonitoring: true,
+	})
+
+	tickC := make(chan time.Time, 1)
+	m := buildMonitor(sw, pl, state, tickC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	tickC <- time.Now()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	if got := pl.calls.Load(); got < 1 {
+		t.Errorf("Pull.Execute call count = %d, want >= 1", got)
+	}
+	if sw.calls.Load() != 0 {
+		t.Errorf("SwitchVideo.Execute should not be called, got %d", sw.calls.Load())
+	}
+}
+
+// TestMonitor_Waiting_NoOp: WAITING 状態では SwitchVideo も Pull も呼ばれない。
+func TestMonitor_Waiting_NoOp(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status: domain.StatusWaiting,
+	})
+
+	tickC := make(chan time.Time, 1)
+	m := buildMonitor(sw, pl, state, tickC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	tickC <- time.Now()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	if sw.calls.Load() != 0 {
+		t.Errorf("SwitchVideo.Execute should not be called, got %d", sw.calls.Load())
+	}
+	if pl.calls.Load() != 0 {
+		t.Errorf("Pull.Execute should not be called, got %d", pl.calls.Load())
+	}
+}
+
+// TestMonitor_CtxCancel_Exits: ctx cancel で Run が return する (goroutine leak なし)。
+func TestMonitor_CtxCancel_Exits(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+	_ = state.Set(context.Background(), domain.LiveState{Status: domain.StatusWaiting})
+
+	// tickC に何も送らない状態でキャンセルしても終わる
+	tickC := make(chan time.Time)
+	m := buildMonitor(sw, pl, state, tickC)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	// 少し待ってから cancel
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel — goroutine leak suspected")
+	}
+}
+
+// TestMonitor_ScheduledStartTime_SleepSkippedIfPast: scheduledStartTime が過去なら sleep せず即 process する。
+func TestMonitor_ScheduledStartTime_SleepSkippedIfPast(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+	pastScheduled := time.Now().Add(-10 * time.Minute) // 過去 → buffer 後も過去
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status:             domain.StatusReserved,
+		VideoID:            "vid_past",
+		ScheduledStartTime: pastScheduled,
+	})
+
+	tickC := make(chan time.Time, 1)
+	m := &monitor.Monitor{
+		SwitchVideo: sw,
+		Pull:        pl,
+		State:       state,
+		Clock:       fixedClock{t: time.Now()},
+		Buffer:      5 * time.Minute,
+		TickC:       tickC,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	// sleep なしなら即 process (initial call) が走るはず
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	elapsed := time.Since(start)
+	// sleep せず即実行 → 100ms 以内に process が呼ばれているはず
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("expected no sleep (past scheduledStartTime), but elapsed=%s", elapsed)
+	}
+	if sw.calls.Load() == 0 {
+		t.Error("SwitchVideo.Execute should have been called at least once")
+	}
+}
+
+// TestMonitor_ScheduledStartTime_SleepsUntilBuffer: scheduledStartTime が未来なら buffer 後まで sleep する。
+func TestMonitor_ScheduledStartTime_SleepsUntilBuffer(t *testing.T) {
+	sw := &fakeSwitcher{}
+	pl := &fakePuller{}
+	state := memory.NewStateRepo()
+
+	now := time.Now()
+	// scheduledStartTime = now + 150ms, buffer = 100ms → wakeAt = now + 50ms
+	scheduled := now.Add(150 * time.Millisecond)
+	buffer := 100 * time.Millisecond
+	_ = state.Set(context.Background(), domain.LiveState{
+		Status:             domain.StatusReserved,
+		VideoID:            "vid_future",
+		ScheduledStartTime: scheduled,
+	})
+
+	tickC := make(chan time.Time) // tick を送らない (sleep 中に cancel する)
+	m := &monitor.Monitor{
+		SwitchVideo: sw,
+		Pull:        pl,
+		State:       state,
+		Clock:       fixedClock{t: now},
+		Buffer:      buffer,
+		TickC:       tickC,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		defer close(done)
+		m.Run(ctx)
+	}()
+
+	// wakeAt (50ms) 前にキャンセル → process が呼ばれないことを確認
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	elapsed := time.Since(start)
+	_ = elapsed
+
+	// 20ms でキャンセルしたので process は呼ばれていないはず
+	if sw.calls.Load() != 0 {
+		t.Errorf("SwitchVideo.Execute should not be called during sleep, got %d calls", sw.calls.Load())
+	}
+}

--- a/backend/internal/usecase/pull.go
+++ b/backend/internal/usecase/pull.go
@@ -61,6 +61,7 @@ func (uc *Pull) Execute(ctx context.Context) (PullOutput, error) {
 		state.Status = domain.StatusWaiting
 		state.EndedAt = uc.Clock.Now()
 		state.NextPageToken = ""
+		state.AutonomousMonitoring = false // monitor の Pull tick を停止
 		if err := uc.State.Set(ctx, state); err != nil {
 			return PullOutput{}, fmt.Errorf("state_set: %w", err)
 		}

--- a/backend/internal/usecase/pull_test.go
+++ b/backend/internal/usecase/pull_test.go
@@ -34,6 +34,9 @@ func (f *fakeYTWithToken) GetChannelDisplayNames(ctx context.Context, channelIDs
 func (f *fakeYTWithToken) GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error) {
 	return nil, nil
 }
+func (f *fakeYTWithToken) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	return port.VideoLiveDetails{}, nil
+}
 func (f *fakeYTWithToken) ListLiveChatMessages(ctx context.Context, liveChatID string, pageToken string) ([]port.ChatMessage, string, int64, int, bool, error) {
 	// messagesフィールドがある場合はそれを使用（新しいテスト用）
 	if f.messages != nil {
@@ -58,6 +61,9 @@ func (f *fakeYTForPull) GetChannelDisplayNames(ctx context.Context, channelIDs [
 func (f *fakeYTForPull) GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error) {
 	return nil, nil
 }
+func (f *fakeYTForPull) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	return port.VideoLiveDetails{}, nil
+}
 
 type fakeClock struct {
 	now time.Time
@@ -65,6 +71,41 @@ type fakeClock struct {
 
 func (f *fakeClock) Now() time.Time {
 	return f.now
+}
+
+// TestPull_OnStreamEnd_ClearsAutonomousMonitoring: 配信終了検知で AutonomousMonitoring=false がクリアされる。
+// monitor の Pull tick を確実に停止する core 仕様。
+func TestPull_OnStreamEnd_ClearsAutonomousMonitoring(t *testing.T) {
+	ctx := context.Background()
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{
+		Status:               domain.StatusActive,
+		VideoID:              "v",
+		LiveChatID:           "live:abc",
+		AutonomousMonitoring: true,
+	})
+	yt := &fakeYTForPull{ended: true} // 配信終了
+	clock := &fakeClock{now: time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)}
+
+	comments := memory.NewCommentRepo()
+	uc := &usecase.Pull{YT: yt, Users: users, Comments: comments, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	out, err := uc.Execute(ctx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !out.AutoReset {
+		t.Error("AutoReset = false, want true")
+	}
+
+	got, _ := state.Get(ctx)
+	if got.Status != domain.StatusWaiting {
+		t.Errorf("Status = %v, want WAITING", got.Status)
+	}
+	if got.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = true, want false (stream end should clear)")
+	}
 }
 
 func TestPull_AddsUsers_NormalFlow(t *testing.T) {

--- a/backend/internal/usecase/reserve.go
+++ b/backend/internal/usecase/reserve.go
@@ -1,0 +1,70 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/logging"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
+)
+
+type ReserveInput struct {
+	VideoID string
+}
+
+type ReserveOutput struct {
+	State domain.LiveState
+}
+
+type Reserve struct {
+	YT    port.YouTubePort
+	State port.StateRepo
+	Clock port.Clock
+	Snap  snapshot.Coordinator
+}
+
+// Execute: videoId を予約状態に遷移。ACTIVE 中なら conflict、非 live なら invalid argument。
+// users/comments は触らない (実際の切替は monitor → SwitchVideo に任せる)。
+func (uc *Reserve) Execute(ctx context.Context, in ReserveInput) (ReserveOutput, error) {
+	if in.VideoID == "" {
+		return ReserveOutput{}, &domain.APIError{Code: domain.ErrCodeInvalidArgument, Message: "videoId is required"}
+	}
+
+	cur, err := uc.State.Get(ctx)
+	if err != nil {
+		return ReserveOutput{}, fmt.Errorf("state_get: %w", err)
+	}
+	if cur.Status == domain.StatusActive {
+		return ReserveOutput{}, &domain.APIError{Code: domain.ErrCodeConflict, Message: "stream is currently active, reset first"}
+	}
+
+	details, err := uc.YT.GetVideoLiveDetails(ctx, in.VideoID)
+	if err != nil {
+		return ReserveOutput{}, fmt.Errorf("get_video_live_details: %w", err)
+	}
+	if !details.IsLiveContent {
+		return ReserveOutput{}, &domain.APIError{Code: domain.ErrCodeInvalidArgument, Message: "video is not a live stream"}
+	}
+
+	now := uc.Clock.Now()
+	newState := domain.LiveState{
+		Status:               domain.StatusReserved,
+		VideoID:              in.VideoID,
+		LiveChatID:           details.LiveChatID, // チャット未開なら空
+		AutonomousMonitoring: true,
+		ReservedAt:           now,
+		ScheduledStartTime:   details.ScheduledStartTime,
+	}
+	if err := uc.State.Set(ctx, newState); err != nil {
+		return ReserveOutput{}, fmt.Errorf("state_set: %w", err)
+	}
+
+	uc.Snap.MarkDirty()
+	if err := uc.Snap.Flush(ctx); err != nil {
+		logging.Log(ctx, "warn", "SNAPSHOT", "reserve: snapshot flush failed: %v", err)
+	}
+
+	return ReserveOutput{State: newState}, nil
+}

--- a/backend/internal/usecase/reserve_test.go
+++ b/backend/internal/usecase/reserve_test.go
@@ -1,0 +1,170 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/memory"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
+)
+
+// fakeYTForReserve は GetVideoLiveDetails の戻り値を制御できる fake。
+type fakeYTForReserve struct {
+	details port.VideoLiveDetails
+	err     error
+}
+
+func (f *fakeYTForReserve) GetActiveLiveChatID(_ context.Context, _ string) (port.VideoMeta, error) {
+	return port.VideoMeta{}, nil
+}
+func (f *fakeYTForReserve) ListLiveChatMessages(_ context.Context, _ string, _ string) ([]port.ChatMessage, string, int64, int, bool, error) {
+	return nil, "", 0, 0, false, nil
+}
+func (f *fakeYTForReserve) GetChannelDisplayNames(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeYTForReserve) GetChannelHandles(_ context.Context, _ []string) (map[string]string, error) {
+	return nil, nil
+}
+func (f *fakeYTForReserve) GetVideoLiveDetails(_ context.Context, _ string) (port.VideoLiveDetails, error) {
+	return f.details, f.err
+}
+
+func TestReserve_WaitingAndIsLive_SetsReserved(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	scheduled := time.Date(2026, 7, 1, 18, 0, 0, 0, time.UTC)
+	yt := &fakeYTForReserve{
+		details: port.VideoLiveDetails{
+			LiveChatID:         "",
+			IsLiveContent:      true,
+			ScheduledStartTime: scheduled,
+		},
+	}
+	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	clock := fixedClock{t: now}
+
+	uc := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	out, err := uc.Execute(ctx, usecase.ReserveInput{VideoID: "vid-reserved"})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if out.State.Status != domain.StatusReserved {
+		t.Errorf("Status = %v, want %v", out.State.Status, domain.StatusReserved)
+	}
+	if out.State.VideoID != "vid-reserved" {
+		t.Errorf("VideoID = %v, want vid-reserved", out.State.VideoID)
+	}
+	if !out.State.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = false, want true")
+	}
+	if !out.State.ScheduledStartTime.Equal(scheduled) {
+		t.Errorf("ScheduledStartTime = %v, want %v", out.State.ScheduledStartTime, scheduled)
+	}
+	if !out.State.ReservedAt.Equal(now) {
+		t.Errorf("ReservedAt = %v, want %v", out.State.ReservedAt, now)
+	}
+
+	// state に保存されているか確認
+	persisted, _ := state.Get(ctx)
+	if persisted.Status != domain.StatusReserved {
+		t.Errorf("persisted Status = %v, want %v", persisted.Status, domain.StatusReserved)
+	}
+}
+
+func TestReserve_ActiveStatus_ReturnsConflict(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusActive, VideoID: "current"})
+
+	yt := &fakeYTForReserve{details: port.VideoLiveDetails{IsLiveContent: true}}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	_, err := uc.Execute(ctx, usecase.ReserveInput{VideoID: "vid-new"})
+	if err == nil {
+		t.Fatal("Execute should return error on ACTIVE status")
+	}
+	var apiErr *domain.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *domain.APIError", err)
+	}
+	if apiErr.Code != domain.ErrCodeConflict {
+		t.Errorf("Code = %v, want %v", apiErr.Code, domain.ErrCodeConflict)
+	}
+}
+
+func TestReserve_EmptyVideoID_ReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	yt := &fakeYTForReserve{}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	_, err := uc.Execute(ctx, usecase.ReserveInput{VideoID: ""})
+	if err == nil {
+		t.Fatal("Execute should return error on empty videoId")
+	}
+	var apiErr *domain.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *domain.APIError", err)
+	}
+	if apiErr.Code != domain.ErrCodeInvalidArgument {
+		t.Errorf("Code = %v, want %v", apiErr.Code, domain.ErrCodeInvalidArgument)
+	}
+}
+
+func TestReserve_NotLiveContent_ReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	// IsLiveContent = false: 通常動画に対する予約
+	yt := &fakeYTForReserve{details: port.VideoLiveDetails{IsLiveContent: false}}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	_, err := uc.Execute(ctx, usecase.ReserveInput{VideoID: "vid-normal"})
+	if err == nil {
+		t.Fatal("Execute should return error on non-live video")
+	}
+	var apiErr *domain.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *domain.APIError", err)
+	}
+	if apiErr.Code != domain.ErrCodeInvalidArgument {
+		t.Errorf("Code = %v, want %v", apiErr.Code, domain.ErrCodeInvalidArgument)
+	}
+}
+
+func TestReserve_YTAPIError_ReturnsWrappedError(t *testing.T) {
+	ctx := context.Background()
+
+	state := memory.NewStateRepo()
+	yt := &fakeYTForReserve{err: errors.New("youtube api quota exceeded")}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	_, err := uc.Execute(ctx, usecase.ReserveInput{VideoID: "vid-x"})
+	if err == nil {
+		t.Fatal("Execute should return error on YT API failure")
+	}
+	// *domain.APIError ではなく wrapped error として返る
+	var apiErr *domain.APIError
+	if errors.As(err, &apiErr) {
+		t.Errorf("should not be *domain.APIError, got code=%v", apiErr.Code)
+	}
+}

--- a/backend/internal/usecase/status.go
+++ b/backend/internal/usecase/status.go
@@ -9,13 +9,16 @@ import (
 )
 
 type StatusOutput struct {
-	Status       domain.Status
-	Count        int
-	VideoID      string
-	LiveChatID   string
-	StartedAt    time.Time
-	EndedAt      time.Time
-	LastPulledAt time.Time
+	Status               domain.Status
+	Count                int
+	VideoID              string
+	LiveChatID           string
+	StartedAt            time.Time
+	EndedAt              time.Time
+	LastPulledAt         time.Time
+	ReservedAt           time.Time
+	ScheduledStartTime   time.Time
+	AutonomousMonitoring bool
 }
 
 type Status struct {
@@ -34,12 +37,15 @@ func (uc *Status) Execute(ctx context.Context) (StatusOutput, error) {
 	count := uc.Users.Count()
 
 	return StatusOutput{
-		Status:       state.Status,
-		Count:        count,
-		VideoID:      state.VideoID,
-		LiveChatID:   state.LiveChatID,
-		StartedAt:    state.StartedAt,
-		EndedAt:      state.EndedAt,
-		LastPulledAt: state.LastPulledAt,
+		Status:               state.Status,
+		Count:                count,
+		VideoID:              state.VideoID,
+		LiveChatID:           state.LiveChatID,
+		StartedAt:            state.StartedAt,
+		EndedAt:              state.EndedAt,
+		LastPulledAt:         state.LastPulledAt,
+		ReservedAt:           state.ReservedAt,
+		ScheduledStartTime:   state.ScheduledStartTime,
+		AutonomousMonitoring: state.AutonomousMonitoring,
 	}, nil
 }

--- a/backend/internal/usecase/switch_video.go
+++ b/backend/internal/usecase/switch_video.go
@@ -45,12 +45,13 @@ func (uc *SwitchVideo) Execute(ctx context.Context, in SwitchVideoInput) (Switch
 				startedAt = now
 			}
 			restoredState := domain.LiveState{
-				Status:        domain.StatusWaiting,
-				VideoID:       in.VideoID,
-				LiveChatID:    prevState.LiveChatID,
-				StartedAt:     startedAt,
-				EndedAt:       now,
-				NextPageToken: "",
+				Status:               domain.StatusWaiting,
+				VideoID:              in.VideoID,
+				LiveChatID:           prevState.LiveChatID,
+				StartedAt:            startedAt,
+				EndedAt:              now,
+				NextPageToken:        "",
+				AutonomousMonitoring: false, // フォールバックで明示的に false (永続化漏れ防止)
 			}
 			if setErr := uc.State.Set(ctx, restoredState); setErr != nil {
 				return SwitchVideoOutput{}, fmt.Errorf("state_set: %w", setErr)
@@ -84,12 +85,13 @@ func (uc *SwitchVideo) Execute(ctx context.Context, in SwitchVideoInput) (Switch
 			startedAt = now
 		}
 		finalState := domain.LiveState{
-			Status:        domain.StatusWaiting,
-			VideoID:       in.VideoID,
-			LiveChatID:    restoredState.LiveChatID,
-			StartedAt:     startedAt,
-			EndedAt:       now,
-			NextPageToken: "",
+			Status:               domain.StatusWaiting,
+			VideoID:              in.VideoID,
+			LiveChatID:           restoredState.LiveChatID,
+			StartedAt:            startedAt,
+			EndedAt:              now,
+			NextPageToken:        "",
+			AutonomousMonitoring: false, // フォールバックで明示的に false (永続化漏れ防止)
 		}
 		if setErr := uc.State.Set(ctx, finalState); setErr != nil {
 			return SwitchVideoOutput{}, fmt.Errorf("state_set: %w", setErr)
@@ -133,11 +135,12 @@ func (uc *SwitchVideo) Execute(ctx context.Context, in SwitchVideoInput) (Switch
 		}
 	}
 	newState := domain.LiveState{
-		Status:        domain.StatusActive,
-		VideoID:       in.VideoID,
-		LiveChatID:    meta.LiveChatID,
-		StartedAt:     startedAt,
-		NextPageToken: "",
+		Status:               domain.StatusActive,
+		VideoID:              in.VideoID,
+		LiveChatID:           meta.LiveChatID,
+		StartedAt:            startedAt,
+		NextPageToken:        "",
+		AutonomousMonitoring: prevState.AutonomousMonitoring, // Reserve 経由なら true を維持
 	}
 
 	if err := uc.State.Set(ctx, newState); err != nil {

--- a/backend/internal/usecase/switch_video_test.go
+++ b/backend/internal/usecase/switch_video_test.go
@@ -40,6 +40,9 @@ func (f *failingYT) GetChannelDisplayNames(ctx context.Context, channelIDs []str
 func (f *failingYT) GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error) {
 	return nil, nil
 }
+func (f *failingYT) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	return port.VideoLiveDetails{}, nil
+}
 func (f *fakeYT) ListLiveChatMessages(ctx context.Context, liveChatID string, pageToken string) ([]port.ChatMessage, string, int64, int, bool, error) {
 	return nil, "", 0, 0, false, nil
 }
@@ -48,6 +51,9 @@ func (f *fakeYT) GetChannelDisplayNames(ctx context.Context, channelIDs []string
 }
 func (f *fakeYT) GetChannelHandles(ctx context.Context, channelIDs []string) (map[string]string, error) {
 	return nil, nil
+}
+func (f *fakeYT) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
+	return port.VideoLiveDetails{}, nil
 }
 
 type fixedClock struct{ t time.Time }
@@ -228,6 +234,99 @@ func TestSwitchVideo_APIError_SameVideoID_NoUsers_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestSwitchVideo_PreservesAutonomousMonitoring: Reserve→ACTIVE 遷移時に AutonomousMonitoring=true が維持されること。
+// monitor が ACTIVE 後も Pull tick を継続する依存 (servers-side reserve flow の core 仕様)。
+func TestSwitchVideo_PreservesAutonomousMonitoring(t *testing.T) {
+	ctx := context.Background()
+
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	// 予約済 (Reserve usecase が書いた状態を模す)
+	_ = state.Set(ctx, domain.LiveState{
+		Status:               domain.StatusReserved,
+		VideoID:              "video123",
+		AutonomousMonitoring: true,
+		ReservedAt:           time.Date(2026, 6, 21, 9, 0, 0, 0, time.UTC),
+		ScheduledStartTime:   time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC),
+	})
+
+	yt := &fakeYT{}
+	clock := fixedClock{t: time.Date(2026, 6, 21, 10, 5, 0, 0, time.UTC)}
+
+	uc := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	if _, err := uc.Execute(ctx, usecase.SwitchVideoInput{VideoID: "video123"}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	got, _ := state.Get(ctx)
+	if got.Status != domain.StatusActive {
+		t.Errorf("Status = %v, want ACTIVE", got.Status)
+	}
+	if !got.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = false, want true (Reserve→ACTIVE 遷移時に引き継がれるべき)")
+	}
+}
+
+// TestSwitchVideo_ManualSwitch_NoAutonomousMonitoring: 手動 SwitchVideo (prevState.AM=false) は AM=false のまま。
+// monitor の Pull tick を起動しない仕様 (フロント pull のみで動かす既存挙動の維持)。
+func TestSwitchVideo_ManualSwitch_NoAutonomousMonitoring(t *testing.T) {
+	ctx := context.Background()
+
+	users := memory.NewUserRepo()
+	state := memory.NewStateRepo()
+	// WAITING (AM はゼロ値 = false)
+	_ = state.Set(ctx, domain.LiveState{Status: domain.StatusWaiting})
+
+	yt := &fakeYT{}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	if _, err := uc.Execute(ctx, usecase.SwitchVideoInput{VideoID: "video123"}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	got, _ := state.Get(ctx)
+	if got.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = true, want false (manual switch は autonomous でない)")
+	}
+}
+
+// TestSwitchVideo_APIError_InMemoryFallback_ClearsAutonomousMonitoring:
+// API error フォールバックの in-memory 復元パスで AutonomousMonitoring=false が強制クリアされる。
+// 配信終了 → WAITING 復元時に monitor の Pull tick を確実に停止するため (永続化漏れ防止)。
+func TestSwitchVideo_APIError_InMemoryFallback_ClearsAutonomousMonitoring(t *testing.T) {
+	ctx := context.Background()
+
+	users := memory.NewUserRepo()
+	_ = users.UpsertWithJoinTime("ch1", "Alice", time.Now())
+
+	state := memory.NewStateRepo()
+	_ = state.Set(ctx, domain.LiveState{
+		Status:               domain.StatusActive,
+		VideoID:              "video123",
+		LiveChatID:           "live:abc",
+		AutonomousMonitoring: true,
+	})
+
+	yt := &failingYT{}
+	clock := fixedClock{t: time.Now()}
+
+	uc := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+
+	out, err := uc.Execute(ctx, usecase.SwitchVideoInput{VideoID: "video123"})
+	if err != nil {
+		t.Fatalf("Execute should succeed (in-memory fallback): %v", err)
+	}
+	if out.State.Status != domain.StatusWaiting {
+		t.Errorf("Status = %v, want WAITING", out.State.Status)
+	}
+	if out.State.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = true, want false (fallback should force clear)")
+	}
+}
+
 // TestSwitchVideo_DifferentVideo_ClearsComments: 別 video 切替で CommentRepo がクリアされる
 func TestSwitchVideo_DifferentVideo_ClearsComments(t *testing.T) {
 	ctx := context.Background()
@@ -378,6 +477,10 @@ func TestSwitchVideo_APIError_RestoreFromGCS_succeeds(t *testing.T) {
 	// EndedAt は now
 	if !out.State.EndedAt.Equal(now) {
 		t.Errorf("State.EndedAt = %v, want %v", out.State.EndedAt, now)
+	}
+	// GCS fallback でも AutonomousMonitoring=false を強制クリア
+	if out.State.AutonomousMonitoring {
+		t.Error("AutonomousMonitoring = true, want false (GCS fallback should force clear)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- 不在時に配信開始を待ち受ける用途で `POST /reserve` `POST /cancel-reserve` を新設
- background monitor goroutine が `scheduledStartTime - 5min` まで sleep してから 60s tick で既存 `SwitchVideo` を呼び、ACTIVE 後は `Pull` を回す
- 既存 `/switch-video` `/pull` `/reset` とフロント自動取得は無変更 (regression なし)
- ACTIVE 中の `/reserve` `/cancel-reserve` は 409 で拒否し、現セッションを守る
- 派生: Google API が `Details[].ErrorInfo.reason` に詰めて返す API_KEY_INVALID 等を読むよう adapter を修正、API key 不正時に 500 → 401 になる

## Why

curl で「配信前に予約だけ仕掛けて不在中にサーバーが自動で切替・取得まで進める」運用を実現するため。フロントの「切替ボタン」操作は今まで通り並存。

## Design notes

- `domain.LiveState` に `Status=RESERVED` と `AutonomousMonitoring` / `ReservedAt` / `ScheduledStartTime` を追加。Reserve 経由 ACTIVE のみ monitor が Pull を継続し、手動 ACTIVE は従来通りフロント pull のみ
- Reserve の videoId 検証は新 `GetVideoLiveDetails` (`liveStreamingDetails` 取得、`activeLiveChatId` 空でも error にしない) を経由
- monitor は test 容易性のため tick channel inject 可能、`switcher` / `puller` を unexported interface 化
- TOCTOU race (monitor tick と cancel-reserve 並行) は MVP 許容、観測 log のみ。Cloud Run min/max instance=1 前提
- `/reserve` `/cancel-reserve` は既存 `renderUsecaseError` ヘルパーに統一、`httpStatusFor` に Conflict/InvalidArgument を追加。video_not_found を 404 に正しくマッピング

## Test plan

- [x] `go build ./...` 0 error
- [x] `go test ./...` 全 pass (新規 reserve / cancel_reserve / monitor + 既存 regression)
- [x] `go test -race ./...` race 検出 0
- [x] `go vet ./...` 0 warning
- [x] handlers integration test 6 ケース (200 / 400 空 / 400 非live / 404 / 409 reserve / 409 cancel / 200 cancel)
- [x] AutonomousMonitoring lifecycle 5 ケース (引継ぎ / 手動 switch / API error fallback 2 経路 / stream end)
- [x] classifyAPIError 3 ケース追加 (API_KEY_INVALID 旧/新形式 + Details 優先)
- [x] 手動 e2e: `/status` 新 field 露出 / `/reserve` 各 error path / `/cancel-reserve` 冪等 / monitor 起動 log / graceful shutdown / dummy YT key で 401 観測
- [ ] (未確認、user 環境) valid YT_API_KEY + 実 live videoId での Reserve→ACTIVE 自動遷移と Pull 継続