### PR TITLE
開始/取得を1ボタン化、backend dispatcherで予約と切替を自動判別

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -89,7 +89,6 @@ func main() {
 
 	h := &ahttp.Handlers{
 		Status:         ucStatus,
-		SwitchVideo:    ucSwitch,
 		Pull:           ucPull,
 		Reset:          ucReset,
 		Reserve:        ucReserve,

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -93,6 +93,8 @@ func main() {
 		Coord:         coord,
 		ListHistory:   listHistory,
 		GetHistory:    getHistory,
+		YT:            yt,
+		Clock:         clock,
 	}
 	srv := &http.Server{Addr: ":" + cfg.Port, Handler: ahttp.NewRouter(h, cfg.FrontendOrigin)}
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -80,21 +80,26 @@ func main() {
 	ucReset := &usecase.Reset{Users: users, Comments: comments, State: state, Snap: coord}
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	ucCancelReserve := &usecase.CancelReserve{State: state, Snap: coord}
+	ucStartOrReserve := &usecase.StartOrReserve{
+		YT:          yt,
+		Clock:       clock,
+		SwitchVideo: ucSwitch,
+		Reserve:     ucReserve,
+	}
 
 	h := &ahttp.Handlers{
-		Status:        ucStatus,
-		SwitchVideo:   ucSwitch,
-		Pull:          ucPull,
-		Reset:         ucReset,
-		Reserve:       ucReserve,
-		CancelReserve: ucCancelReserve,
-		Users:         users,
-		Comments:      comments,
-		Coord:         coord,
-		ListHistory:   listHistory,
-		GetHistory:    getHistory,
-		YT:            yt,
-		Clock:         clock,
+		Status:         ucStatus,
+		SwitchVideo:    ucSwitch,
+		Pull:           ucPull,
+		Reset:          ucReset,
+		Reserve:        ucReserve,
+		CancelReserve:  ucCancelReserve,
+		Users:          users,
+		Comments:       comments,
+		Coord:          coord,
+		ListHistory:    listHistory,
+		GetHistory:     getHistory,
+		StartOrReserve: ucStartOrReserve,
 	}
 	srv := &http.Server{Addr: ":" + cfg.Port, Handler: ahttp.NewRouter(h, cfg.FrontendOrigin)}
 

--- a/backend/internal/adapter/http/handlers.go
+++ b/backend/internal/adapter/http/handlers.go
@@ -29,6 +29,9 @@ type Handlers struct {
 	Coord         snapshot.Coordinator
 	ListHistory   *usecase.ListHistorySnapshots
 	GetHistory    *usecase.GetHistorySnapshot
+	// YT / Clock は /switch-video の dispatcher (未開始なら Reserve 振り分け) で利用。
+	YT    port.YouTubePort
+	Clock port.Clock
 }
 
 // StatusResponse represents the response for /status endpoint
@@ -49,11 +52,13 @@ type StatusResponse struct {
 
 // SwitchVideoResponse represents the response for /switch-video endpoint
 type SwitchVideoResponse struct {
-	Status     string      `json:"status"`
-	VideoID    string      `json:"videoId"`
-	LiveChatID string      `json:"liveChatId"`
-	StartedAt  any         `json:"startedAt"`
-	Logs       []LogDetail `json:"logs,omitempty"`
+	Status             string      `json:"status"`
+	VideoID            string      `json:"videoId"`
+	LiveChatID         string      `json:"liveChatId"`
+	StartedAt          any         `json:"startedAt"`
+	ScheduledStartTime any         `json:"scheduledStartTime,omitempty"`
+	ReservedAt         any         `json:"reservedAt,omitempty"`
+	Logs               []LogDetail `json:"logs,omitempty"`
 }
 
 // LogDetail represents a single log entry in the response
@@ -196,6 +201,40 @@ func NewRouter(h *Handlers, frontendOrigin string) stdhttp.Handler {
 		}
 
 		log.Printf("[SWITCH_VIDEO] Successfully extracted videoID: '%s' (length: %d) from: '%s'", videoID, len(videoID), req.VideoID)
+
+		// Dispatcher: 未開始の配信 (actualStartTime zero or scheduledStartTime 未来) なら Reserve に振り分ける。
+		// monitor.go の判定式と同一。
+		if h.YT != nil && h.Clock != nil && h.Reserve != nil {
+			details, derr := h.YT.GetVideoLiveDetails(r.Context(), videoID)
+			if derr != nil {
+				log.Printf("[SWITCH_VIDEO] GetVideoLiveDetails error: %v", derr)
+				renderUsecaseError(w, r, derr, "Failed to get video details: "+derr.Error(), collector, StatusBadGateway, "bad_gateway")
+				return
+			}
+			now := h.Clock.Now()
+			scheduledFuture := !details.ScheduledStartTime.IsZero() && details.ScheduledStartTime.After(now)
+			if details.IsLiveContent && (details.ActualStartTime.IsZero() || scheduledFuture) {
+				log.Printf("[SWITCH_VIDEO] Dispatching to Reserve (videoId=%s actualStart=%v scheduled=%v)", videoID, details.ActualStartTime, details.ScheduledStartTime)
+				rout, rerr := h.Reserve.Execute(r.Context(), usecase.ReserveInput{VideoID: videoID})
+				if rerr != nil {
+					log.Printf("[SWITCH_VIDEO] Reserve.Execute error: %v", rerr)
+					renderUsecaseError(w, r, rerr, "Failed to reserve: "+rerr.Error(), collector, StatusInternalServerError, "internal_error")
+					return
+				}
+				response := SwitchVideoResponse{
+					Status:             string(rout.State.Status),
+					VideoID:            rout.State.VideoID,
+					LiveChatID:         rout.State.LiveChatID,
+					StartedAt:          rout.State.StartedAt,
+					ScheduledStartTime: rout.State.ScheduledStartTime,
+					ReservedAt:         rout.State.ReservedAt,
+					Logs:               collectLogs(collector),
+				}
+				render.JSON(w, r, response)
+				return
+			}
+		}
+
 		log.Printf("[SWITCH_VIDEO] Calling SwitchVideo.Execute with videoID: '%s'", videoID)
 		out, err := h.SwitchVideo.Execute(r.Context(), usecase.SwitchVideoInput{VideoID: videoID})
 		if err != nil {

--- a/backend/internal/adapter/http/handlers.go
+++ b/backend/internal/adapter/http/handlers.go
@@ -18,20 +18,18 @@ import (
 )
 
 type Handlers struct {
-	Status        *usecase.Status
-	SwitchVideo   *usecase.SwitchVideo
-	Pull          *usecase.Pull
-	Reset         *usecase.Reset
-	Reserve       *usecase.Reserve
-	CancelReserve *usecase.CancelReserve
-	Users         port.UserRepo
-	Comments      port.CommentRepo
-	Coord         snapshot.Coordinator
-	ListHistory   *usecase.ListHistorySnapshots
-	GetHistory    *usecase.GetHistorySnapshot
-	// YT / Clock は /switch-video の dispatcher (未開始なら Reserve 振り分け) で利用。
-	YT    port.YouTubePort
-	Clock port.Clock
+	Status         *usecase.Status
+	SwitchVideo    *usecase.SwitchVideo
+	Pull           *usecase.Pull
+	Reset          *usecase.Reset
+	Reserve        *usecase.Reserve
+	CancelReserve  *usecase.CancelReserve
+	StartOrReserve *usecase.StartOrReserve
+	Users          port.UserRepo
+	Comments       port.CommentRepo
+	Coord          snapshot.Coordinator
+	ListHistory    *usecase.ListHistorySnapshots
+	GetHistory     *usecase.GetHistorySnapshot
 }
 
 // StatusResponse represents the response for /status endpoint
@@ -201,55 +199,23 @@ func NewRouter(h *Handlers, frontendOrigin string) stdhttp.Handler {
 		}
 
 		log.Printf("[SWITCH_VIDEO] Successfully extracted videoID: '%s' (length: %d) from: '%s'", videoID, len(videoID), req.VideoID)
-
-		// Dispatcher: 未開始の配信 (actualStartTime zero or scheduledStartTime 未来) なら Reserve に振り分ける。
-		// monitor.go の判定式と同一。
-		if h.YT != nil && h.Clock != nil && h.Reserve != nil {
-			details, derr := h.YT.GetVideoLiveDetails(r.Context(), videoID)
-			if derr != nil {
-				log.Printf("[SWITCH_VIDEO] GetVideoLiveDetails error: %v", derr)
-				renderUsecaseError(w, r, derr, "Failed to get video details: "+derr.Error(), collector, StatusBadGateway, "bad_gateway")
-				return
-			}
-			now := h.Clock.Now()
-			scheduledFuture := !details.ScheduledStartTime.IsZero() && details.ScheduledStartTime.After(now)
-			if details.IsLiveContent && (details.ActualStartTime.IsZero() || scheduledFuture) {
-				log.Printf("[SWITCH_VIDEO] Dispatching to Reserve (videoId=%s actualStart=%v scheduled=%v)", videoID, details.ActualStartTime, details.ScheduledStartTime)
-				rout, rerr := h.Reserve.Execute(r.Context(), usecase.ReserveInput{VideoID: videoID})
-				if rerr != nil {
-					log.Printf("[SWITCH_VIDEO] Reserve.Execute error: %v", rerr)
-					renderUsecaseError(w, r, rerr, "Failed to reserve: "+rerr.Error(), collector, StatusInternalServerError, "internal_error")
-					return
-				}
-				response := SwitchVideoResponse{
-					Status:             string(rout.State.Status),
-					VideoID:            rout.State.VideoID,
-					LiveChatID:         rout.State.LiveChatID,
-					StartedAt:          rout.State.StartedAt,
-					ScheduledStartTime: rout.State.ScheduledStartTime,
-					ReservedAt:         rout.State.ReservedAt,
-					Logs:               collectLogs(collector),
-				}
-				render.JSON(w, r, response)
-				return
-			}
-		}
-
-		log.Printf("[SWITCH_VIDEO] Calling SwitchVideo.Execute with videoID: '%s'", videoID)
-		out, err := h.SwitchVideo.Execute(r.Context(), usecase.SwitchVideoInput{VideoID: videoID})
+		log.Printf("[SWITCH_VIDEO] Calling StartOrReserve.Execute with videoID: '%s'", videoID)
+		out, err := h.StartOrReserve.Execute(r.Context(), usecase.StartOrReserveInput{VideoID: videoID})
 		if err != nil {
 			log.Printf("[SWITCH_VIDEO] Execute error: %v", err)
 			renderUsecaseError(w, r, err, "Failed to switch video: "+err.Error(), collector, StatusBadGateway, "bad_gateway")
 			return
 		}
 
-		log.Printf("[SWITCH_VIDEO] Successfully switched to video %s, status: %s", out.State.VideoID, out.State.Status)
+		log.Printf("[SWITCH_VIDEO] Dispatched=%s videoId=%s status=%s", out.Dispatched, out.State.VideoID, out.State.Status)
 		response := SwitchVideoResponse{
-			Status:     string(out.State.Status),
-			VideoID:    out.State.VideoID,
-			LiveChatID: out.State.LiveChatID,
-			StartedAt:  out.State.StartedAt,
-			Logs:       collectLogs(collector),
+			Status:             string(out.State.Status),
+			VideoID:            out.State.VideoID,
+			LiveChatID:         out.State.LiveChatID,
+			StartedAt:          out.State.StartedAt,
+			ScheduledStartTime: out.State.ScheduledStartTime,
+			ReservedAt:         out.State.ReservedAt,
+			Logs:               collectLogs(collector),
 		}
 		render.JSON(w, r, response)
 	})

--- a/backend/internal/adapter/http/handlers.go
+++ b/backend/internal/adapter/http/handlers.go
@@ -19,7 +19,6 @@ import (
 
 type Handlers struct {
 	Status         *usecase.Status
-	SwitchVideo    *usecase.SwitchVideo
 	Pull           *usecase.Pull
 	Reset          *usecase.Reset
 	Reserve        *usecase.Reserve

--- a/backend/internal/adapter/http/handlers_integration_test.go
+++ b/backend/internal/adapter/http/handlers_integration_test.go
@@ -60,17 +60,18 @@ func newTestServerWithReserve(yt port.YouTubePort) *httptest.Server {
 	clock := system.NewSystemClock()
 	coord := &snapshot.NopCoordinator{}
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
-		Status:        &usecase.Status{Users: users, State: state},
-		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
-		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
-		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
-		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
-		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
-		Users:         users,
-		Coord:         coord,
-		YT:            yt,
-		Clock:         clock,
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:        ucReserve,
+		CancelReserve:  &usecase.CancelReserve{State: state, Snap: coord},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          coord,
 	}
 	return httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 }
@@ -95,13 +96,16 @@ func newTestServerWithCoord(frontend string, coord snapshot.Coordinator) *httpte
 	yt := youtube.New("") // テスト用の空キー
 	clock := system.NewSystemClock()
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	h := &ahttp.Handlers{
-		Status:      &usecase.Status{Users: users, State: state},
-		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
-		Pull:        &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Reset:       &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Users:       users,
-		Coord:       coord,
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          coord,
 	}
 	router := ahttp.NewRouter(h, frontend)
 	return httptest.NewServer(router)
@@ -162,15 +166,18 @@ func newTestServerWithHistory(sink *fakeSnapshotSink) *httptest.Server {
 	yt := youtube.New("")
 	clock := system.NewSystemClock()
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	h := &ahttp.Handlers{
-		Status:      &usecase.Status{Users: users, State: state},
-		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
-		Pull:        &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Reset:       &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Users:       users,
-		Coord:       &snapshot.NopCoordinator{},
-		ListHistory: &usecase.ListHistorySnapshots{Sink: sink},
-		GetHistory:  &usecase.GetHistorySnapshot{Sink: sink},
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          &snapshot.NopCoordinator{},
+		ListHistory:    &usecase.ListHistorySnapshots{Sink: sink},
+		GetHistory:     &usecase.GetHistorySnapshot{Sink: sink},
 	}
 	router := ahttp.NewRouter(h, "http://example.com")
 	return httptest.NewServer(router)
@@ -545,17 +552,18 @@ func TestReserve_ConflictWhenActive(t *testing.T) {
 	// 事前に ACTIVE 状態を作る
 	_ = state.Set(context.Background(), domain.LiveState{Status: domain.StatusActive, VideoID: "existing"})
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
-		Status:        &usecase.Status{Users: users, State: state},
-		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
-		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
-		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
-		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
-		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
-		Users:         users,
-		Coord:         coord,
-		YT:            yt,
-		Clock:         clock,
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:        ucReserve,
+		CancelReserve:  &usecase.CancelReserve{State: state, Snap: coord},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          coord,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -635,17 +643,18 @@ func TestCancelReserve_ConflictWhenActive(t *testing.T) {
 
 	_ = state.Set(context.Background(), domain.LiveState{Status: domain.StatusActive, VideoID: "existing"})
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
-		Status:        &usecase.Status{Users: users, State: state},
-		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
-		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
-		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
-		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
-		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
-		Users:         users,
-		Coord:         coord,
-		YT:            yt,
-		Clock:         clock,
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:        ucReserve,
+		CancelReserve:  &usecase.CancelReserve{State: state, Snap: coord},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          coord,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -676,17 +685,18 @@ func TestCancelReserve_Success(t *testing.T) {
 		VideoID: "VID123",
 	})
 
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
-		Status:        &usecase.Status{Users: users, State: state},
-		SwitchVideo:   &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: coord},
-		Pull:          &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
-		Reset:         &usecase.Reset{Users: users, State: state, Snap: coord},
-		Reserve:       &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord},
-		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
-		Users:         users,
-		Coord:         coord,
-		YT:            yt,
-		Clock:         clock,
+		Status:         &usecase.Status{Users: users, State: state},
+		SwitchVideo:    ucSwitch,
+		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
+		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
+		Reserve:        ucReserve,
+		CancelReserve:  &usecase.CancelReserve{State: state, Snap: coord},
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
+		Users:          users,
+		Coord:          coord,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -801,7 +811,7 @@ func TestSwitchVideo_DispatchesToReserve_WhenNotStarted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /switch-video: %v", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != stdhttp.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
@@ -833,7 +843,7 @@ func TestSwitchVideo_DispatchesToReserve_WhenScheduledFuture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /switch-video: %v", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != stdhttp.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)
@@ -862,7 +872,7 @@ func TestSwitchVideo_SwitchesDirectly_WhenStarted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST /switch-video: %v", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != stdhttp.StatusOK {
 		t.Fatalf("status = %d, want 200", res.StatusCode)

--- a/backend/internal/adapter/http/handlers_integration_test.go
+++ b/backend/internal/adapter/http/handlers_integration_test.go
@@ -64,7 +64,6 @@ func newTestServerWithReserve(yt port.YouTubePort) *httptest.Server {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
 		Reserve:        ucReserve,
@@ -100,7 +99,6 @@ func newTestServerWithCoord(frontend string, coord snapshot.Coordinator) *httpte
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
 		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
@@ -170,7 +168,6 @@ func newTestServerWithHistory(sink *fakeSnapshotSink) *httptest.Server {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
 		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
@@ -435,15 +432,13 @@ func TestRouter_StatusResponseHasNoLogsField(t *testing.T) {
 	users := memory.NewUserRepo()
 	state := memory.NewStateRepo()
 	yt := youtube.New("")
-	clock := system.NewSystemClock()
 
 	h := &ahttp.Handlers{
-		Status:      &usecase.Status{Users: users, State: state},
-		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
-		Pull:        &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Reset:       &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
-		Users:       users,
-		Coord:       &snapshot.NopCoordinator{},
+		Status: &usecase.Status{Users: users, State: state},
+		Pull:   &usecase.Pull{YT: yt, Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		Reset:  &usecase.Reset{Users: users, State: state, Snap: &snapshot.NopCoordinator{}},
+		Users:  users,
+		Coord:  &snapshot.NopCoordinator{},
 	}
 
 	// NewRouter が組む production middleware 順 (Recover 外側 → Collector 内側) を利用する。
@@ -556,7 +551,6 @@ func TestReserve_ConflictWhenActive(t *testing.T) {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
 		Reserve:        ucReserve,
@@ -647,7 +641,6 @@ func TestCancelReserve_ConflictWhenActive(t *testing.T) {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
 		Reserve:        ucReserve,
@@ -689,7 +682,6 @@ func TestCancelReserve_Success(t *testing.T) {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: coord}
 	h := &ahttp.Handlers{
 		Status:         &usecase.Status{Users: users, State: state},
-		SwitchVideo:    ucSwitch,
 		Pull:           &usecase.Pull{YT: yt, Users: users, State: state, Snap: coord},
 		Reset:          &usecase.Reset{Users: users, State: state, Snap: coord},
 		Reserve:        ucReserve,

--- a/backend/internal/adapter/http/handlers_integration_test.go
+++ b/backend/internal/adapter/http/handlers_integration_test.go
@@ -26,6 +26,7 @@ import (
 type fakeYTForReserve struct {
 	isLive             bool
 	scheduledStartTime time.Time
+	actualStartTime    time.Time
 	getDetailsErr      error
 }
 
@@ -48,6 +49,7 @@ func (f *fakeYTForReserve) GetVideoLiveDetails(_ context.Context, _ string) (por
 	return port.VideoLiveDetails{
 		IsLiveContent:      f.isLive,
 		ScheduledStartTime: f.scheduledStartTime,
+		ActualStartTime:    f.actualStartTime,
 	}, nil
 }
 
@@ -67,6 +69,8 @@ func newTestServerWithReserve(yt port.YouTubePort) *httptest.Server {
 		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
 		Users:         users,
 		Coord:         coord,
+		YT:            yt,
+		Clock:         clock,
 	}
 	return httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 }
@@ -550,6 +554,8 @@ func TestReserve_ConflictWhenActive(t *testing.T) {
 		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
 		Users:         users,
 		Coord:         coord,
+		YT:            yt,
+		Clock:         clock,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -638,6 +644,8 @@ func TestCancelReserve_ConflictWhenActive(t *testing.T) {
 		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
 		Users:         users,
 		Coord:         coord,
+		YT:            yt,
+		Clock:         clock,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -677,6 +685,8 @@ func TestCancelReserve_Success(t *testing.T) {
 		CancelReserve: &usecase.CancelReserve{State: state, Snap: coord},
 		Users:         users,
 		Coord:         coord,
+		YT:            yt,
+		Clock:         clock,
 	}
 	ts := httptest.NewServer(ahttp.NewRouter(h, "http://example.com"))
 	defer ts.Close()
@@ -776,5 +786,92 @@ func TestSuccessResponse_ContainsLogsField(t *testing.T) {
 				t.Errorf("logs key present=%v, want %v; body=%v", hasLogs, tt.wantLogsKey, body)
 			}
 		})
+	}
+}
+
+// TestSwitchVideo_DispatchesToReserve_WhenNotStarted: 未開始 video (actualStartTime zero) は Reserve に振り分けられる。
+func TestSwitchVideo_DispatchesToReserve_WhenNotStarted(t *testing.T) {
+	scheduled := time.Now().Add(12 * time.Hour)
+	yt := &fakeYTForReserve{isLive: true, scheduledStartTime: scheduled} // actualStartTime zero
+	srv := newTestServerWithReserve(yt)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"videoId":"abcdefghijk"}`)
+	res, err := stdhttp.Post(srv.URL+"/switch-video", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /switch-video: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != string(domain.StatusReserved) {
+		t.Errorf("status = %v, want RESERVED", got["status"])
+	}
+	if got["scheduledStartTime"] == nil {
+		t.Error("scheduledStartTime should be present in response")
+	}
+}
+
+// TestSwitchVideo_DispatchesToReserve_WhenScheduledFuture: actualStartTime あっても scheduledStartTime 未来なら Reserve。
+func TestSwitchVideo_DispatchesToReserve_WhenScheduledFuture(t *testing.T) {
+	yt := &fakeYTForReserve{
+		isLive:             true,
+		actualStartTime:    time.Now().Add(-1 * time.Minute), // 立ってる
+		scheduledStartTime: time.Now().Add(6 * time.Hour),    // 未来 (premiere ケース)
+	}
+	srv := newTestServerWithReserve(yt)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"videoId":"premiere001"}`)
+	res, err := stdhttp.Post(srv.URL+"/switch-video", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /switch-video: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != string(domain.StatusReserved) {
+		t.Errorf("status = %v, want RESERVED", got["status"])
+	}
+}
+
+// TestSwitchVideo_SwitchesDirectly_WhenStarted: actualStartTime + scheduledStartTime 過去 なら従来通り SwitchVideo に進む。
+func TestSwitchVideo_SwitchesDirectly_WhenStarted(t *testing.T) {
+	yt := &fakeYTForReserve{
+		isLive:             true,
+		actualStartTime:    time.Now().Add(-10 * time.Minute),
+		scheduledStartTime: time.Now().Add(-15 * time.Minute), // 過去
+	}
+	srv := newTestServerWithReserve(yt)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"videoId":"liveid00001"}`)
+	res, err := stdhttp.Post(srv.URL+"/switch-video", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST /switch-video: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != stdhttp.StatusOK {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != string(domain.StatusActive) {
+		t.Errorf("status = %v, want ACTIVE", got["status"])
 	}
 }

--- a/backend/internal/adapter/http/handlers_video_url_test.go
+++ b/backend/internal/adapter/http/handlers_video_url_test.go
@@ -32,7 +32,12 @@ func (f *fakeYTForURL) GetChannelHandles(ctx context.Context, channelIDs []strin
 	return nil, nil
 }
 func (f *fakeYTForURL) GetVideoLiveDetails(ctx context.Context, videoID string) (port.VideoLiveDetails, error) {
-	return port.VideoLiveDetails{}, nil
+	// URL 抽出テスト用 fake: live 配信が開始済みの状態を返し SwitchVideo にディスパッチされるようにする。
+	return port.VideoLiveDetails{
+		IsLiveContent:   true,
+		LiveChatID:      "live:chat:" + videoID,
+		ActualStartTime: time.Date(2023, 1, 1, 11, 0, 0, 0, time.UTC),
+	}, nil
 }
 
 type fakeClockForURL struct{}
@@ -52,7 +57,6 @@ func TestSwitchVideoWithURL(t *testing.T) {
 	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	handlers := &Handlers{
 		Users:          users,
-		SwitchVideo:    ucSwitch,
 		Reserve:        ucReserve,
 		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
 	}

--- a/backend/internal/adapter/http/handlers_video_url_test.go
+++ b/backend/internal/adapter/http/handlers_video_url_test.go
@@ -48,9 +48,13 @@ func TestSwitchVideoWithURL(t *testing.T) {
 	yt := &fakeYTForURL{}
 
 	clock := &fakeClockForURL{}
+	ucSwitch := &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
+	ucReserve := &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}}
 	handlers := &Handlers{
-		Users:       users,
-		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: users, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+		Users:          users,
+		SwitchVideo:    ucSwitch,
+		Reserve:        ucReserve,
+		StartOrReserve: &usecase.StartOrReserve{YT: yt, Clock: clock, SwitchVideo: ucSwitch, Reserve: ucReserve},
 	}
 
 	router := NewRouter(handlers, "*")

--- a/backend/internal/usecase/monitor/monitor.go
+++ b/backend/internal/usecase/monitor/monitor.go
@@ -137,17 +137,15 @@ func (m *Monitor) process(ctx context.Context) {
 
 	switch {
 	case st.Status == domain.StatusReserved:
-		// 配信開始済みかを判定: ActualStartTime が立っていて、かつ ScheduledStartTime が過去 (or zero) であること
-		// premiere / test broadcast 中は ActualStartTime が先行して立つことがあるため、ScheduledStartTime も併用する
+		// 配信開始済みかを usecase.IsLiveNotStarted で判定 (handler の StartOrReserve と同一述語)。
+		// premiere / test broadcast 中は ActualStartTime が先行して立つことがあるため、ScheduledStartTime も併用する。
 		if m.YT != nil {
 			details, derr := m.YT.GetVideoLiveDetails(ctx, st.VideoID)
 			if derr != nil {
 				logging.Log(ctx, "warn", "MONITOR", "get_video_live_details failed: %v", derr)
 				return
 			}
-			now := m.Clock.Now()
-			scheduledFuture := !details.ScheduledStartTime.IsZero() && details.ScheduledStartTime.After(now)
-			if details.ActualStartTime.IsZero() || scheduledFuture {
+			if usecase.IsLiveNotStarted(details, m.Clock.Now()) {
 				logging.Log(ctx, "info", "MONITOR", "tick: RESERVED, waiting (videoId=%s actualStart=%s scheduled=%s)",
 					st.VideoID, details.ActualStartTime.Format(time.RFC3339), details.ScheduledStartTime.Format(time.RFC3339))
 				return

--- a/backend/internal/usecase/reserve.go
+++ b/backend/internal/usecase/reserve.go
@@ -12,6 +12,8 @@ import (
 
 type ReserveInput struct {
 	VideoID string
+	// Details が非 nil のとき GetVideoLiveDetails をスキップ (StartOrReserve からの再利用)。
+	Details *port.VideoLiveDetails
 }
 
 type ReserveOutput struct {
@@ -40,9 +42,15 @@ func (uc *Reserve) Execute(ctx context.Context, in ReserveInput) (ReserveOutput,
 		return ReserveOutput{}, &domain.APIError{Code: domain.ErrCodeConflict, Message: "stream is currently active, reset first"}
 	}
 
-	details, err := uc.YT.GetVideoLiveDetails(ctx, in.VideoID)
-	if err != nil {
-		return ReserveOutput{}, fmt.Errorf("get_video_live_details: %w", err)
+	var details port.VideoLiveDetails
+	if in.Details != nil {
+		details = *in.Details
+	} else {
+		var err error
+		details, err = uc.YT.GetVideoLiveDetails(ctx, in.VideoID)
+		if err != nil {
+			return ReserveOutput{}, fmt.Errorf("get_video_live_details: %w", err)
+		}
 	}
 	if !details.IsLiveContent {
 		return ReserveOutput{}, &domain.APIError{Code: domain.ErrCodeInvalidArgument, Message: "video is not a live stream"}

--- a/backend/internal/usecase/start_or_reserve.go
+++ b/backend/internal/usecase/start_or_reserve.go
@@ -41,7 +41,13 @@ func (uc *StartOrReserve) Execute(ctx context.Context, in StartOrReserveInput) (
 		return StartOrReserveOutput{}, fmt.Errorf("get_video_live_details: %w", err)
 	}
 
-	if details.IsLiveContent && IsLiveNotStarted(details, uc.Clock.Now()) {
+	// 非 live 動画は Reserve も SwitchVideo も適切でないため、明示的に invalid_argument を返す。
+	// SwitchVideo に fallthrough すると GetActiveLiveChatID の生 API error になりエラー体験が不安定になる。
+	if !details.IsLiveContent {
+		return StartOrReserveOutput{}, &domain.APIError{Code: domain.ErrCodeInvalidArgument, Message: "video is not a live stream"}
+	}
+
+	if IsLiveNotStarted(details, uc.Clock.Now()) {
 		// pre-fetch 済み details を渡し Reserve 側の GetVideoLiveDetails 再呼び出しを回避する。
 		out, rerr := uc.Reserve.Execute(ctx, ReserveInput{VideoID: in.VideoID, Details: &details})
 		if rerr != nil {

--- a/backend/internal/usecase/start_or_reserve.go
+++ b/backend/internal/usecase/start_or_reserve.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+)
+
+// StartOrReserveInput is the input for the StartOrReserve usecase.
+type StartOrReserveInput struct {
+	VideoID string
+}
+
+// StartOrReserveOutput is the output for the StartOrReserve usecase.
+type StartOrReserveOutput struct {
+	State domain.LiveState
+	// Dispatched indicates which sub-usecase was executed: "switch" or "reserve".
+	Dispatched string
+}
+
+// StartOrReserve dispatches a videoId to SwitchVideo (live started) or Reserve (not yet started).
+// Centralises the "live started yet?" predicate so monitor.go and the HTTP handler stay in sync.
+type StartOrReserve struct {
+	YT          port.YouTubePort
+	Clock       port.Clock
+	SwitchVideo *SwitchVideo
+	Reserve     *Reserve
+}
+
+// Execute fetches live details and routes to SwitchVideo or Reserve accordingly.
+func (uc *StartOrReserve) Execute(ctx context.Context, in StartOrReserveInput) (StartOrReserveOutput, error) {
+	if in.VideoID == "" {
+		return StartOrReserveOutput{}, &domain.APIError{Code: domain.ErrCodeInvalidArgument, Message: "videoId is required"}
+	}
+
+	details, err := uc.YT.GetVideoLiveDetails(ctx, in.VideoID)
+	if err != nil {
+		return StartOrReserveOutput{}, fmt.Errorf("get_video_live_details: %w", err)
+	}
+
+	if details.IsLiveContent && IsLiveNotStarted(details, uc.Clock.Now()) {
+		// pre-fetch 済み details を渡し Reserve 側の GetVideoLiveDetails 再呼び出しを回避する。
+		out, rerr := uc.Reserve.Execute(ctx, ReserveInput{VideoID: in.VideoID, Details: &details})
+		if rerr != nil {
+			return StartOrReserveOutput{}, rerr
+		}
+		return StartOrReserveOutput{State: out.State, Dispatched: "reserve"}, nil
+	}
+
+	out, serr := uc.SwitchVideo.Execute(ctx, SwitchVideoInput{VideoID: in.VideoID})
+	if serr != nil {
+		return StartOrReserveOutput{}, serr
+	}
+	return StartOrReserveOutput{State: out.State, Dispatched: "switch"}, nil
+}
+
+// IsLiveNotStarted returns true when the live is reserved/scheduled but not yet broadcasting.
+// Predicate: ActualStartTime is zero OR ScheduledStartTime is in the future (premiere / test broadcast guard).
+// Used by both StartOrReserve (handler-side dispatch) and monitor (tick-side guard) to share the rule.
+func IsLiveNotStarted(details port.VideoLiveDetails, now time.Time) bool {
+	scheduledFuture := !details.ScheduledStartTime.IsZero() && details.ScheduledStartTime.After(now)
+	return details.ActualStartTime.IsZero() || scheduledFuture
+}

--- a/backend/internal/usecase/start_or_reserve_test.go
+++ b/backend/internal/usecase/start_or_reserve_test.go
@@ -75,6 +75,34 @@ func TestStartOrReserve_DispatchesToSwitch_WhenStarted(t *testing.T) {
 	}
 }
 
+func TestStartOrReserve_NotLiveContent_ReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+	state := memory.NewStateRepo()
+	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	yt := &fakeYTForReserve{
+		details: port.VideoLiveDetails{IsLiveContent: false},
+	}
+	clock := fixedClock{t: now}
+	uc := &usecase.StartOrReserve{
+		YT:          yt,
+		Clock:       clock,
+		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: memory.NewUserRepo(), State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+		Reserve:     &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+	}
+
+	_, err := uc.Execute(ctx, usecase.StartOrReserveInput{VideoID: "vid-not-live"})
+	if err == nil {
+		t.Fatal("expected invalid_argument error, got nil")
+	}
+	apiErr, ok := err.(*domain.APIError)
+	if !ok {
+		t.Fatalf("expected *domain.APIError, got %T: %v", err, err)
+	}
+	if apiErr.Code != domain.ErrCodeInvalidArgument {
+		t.Errorf("Code = %v, want ErrCodeInvalidArgument", apiErr.Code)
+	}
+}
+
 func TestIsLiveNotStarted(t *testing.T) {
 	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
 	tests := []struct {

--- a/backend/internal/usecase/start_or_reserve_test.go
+++ b/backend/internal/usecase/start_or_reserve_test.go
@@ -1,0 +1,119 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/adapter/memory"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/domain"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/port"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase"
+	"github.com/obsidian-engine/youtube-comment-user-list/backend/internal/usecase/snapshot"
+)
+
+func TestStartOrReserve_DispatchesToReserve_WhenNotStarted(t *testing.T) {
+	ctx := context.Background()
+	state := memory.NewStateRepo()
+	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	scheduled := now.Add(6 * time.Hour)
+	yt := &fakeYTForReserve{
+		details: port.VideoLiveDetails{
+			IsLiveContent:      true,
+			ScheduledStartTime: scheduled,
+		},
+	}
+	clock := fixedClock{t: now}
+	uc := &usecase.StartOrReserve{
+		YT:          yt,
+		Clock:       clock,
+		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: memory.NewUserRepo(), State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+		Reserve:     &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+	}
+
+	out, err := uc.Execute(ctx, usecase.StartOrReserveInput{VideoID: "vid-reserve"})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if out.Dispatched != "reserve" {
+		t.Errorf("Dispatched = %q, want reserve", out.Dispatched)
+	}
+	if out.State.Status != domain.StatusReserved {
+		t.Errorf("Status = %v, want RESERVED", out.State.Status)
+	}
+}
+
+func TestStartOrReserve_DispatchesToSwitch_WhenStarted(t *testing.T) {
+	ctx := context.Background()
+	state := memory.NewStateRepo()
+	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	yt := &fakeYTForReserve{
+		details: port.VideoLiveDetails{
+			LiveChatID:         "chat123",
+			IsLiveContent:      true,
+			ActualStartTime:    now.Add(-10 * time.Minute),
+			ScheduledStartTime: now.Add(-15 * time.Minute),
+		},
+	}
+	clock := fixedClock{t: now}
+	uc := &usecase.StartOrReserve{
+		YT:          yt,
+		Clock:       clock,
+		SwitchVideo: &usecase.SwitchVideo{YT: yt, Users: memory.NewUserRepo(), State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+		Reserve:     &usecase.Reserve{YT: yt, State: state, Clock: clock, Snap: &snapshot.NopCoordinator{}},
+	}
+
+	out, err := uc.Execute(ctx, usecase.StartOrReserveInput{VideoID: "vid-live"})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if out.Dispatched != "switch" {
+		t.Errorf("Dispatched = %q, want switch", out.Dispatched)
+	}
+	if out.State.Status != domain.StatusActive {
+		t.Errorf("Status = %v, want ACTIVE", out.State.Status)
+	}
+}
+
+func TestIsLiveNotStarted(t *testing.T) {
+	now := time.Date(2026, 6, 21, 10, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		details port.VideoLiveDetails
+		want    bool
+	}{
+		{
+			name: "actualStartTime zero",
+			details: port.VideoLiveDetails{
+				IsLiveContent: true,
+			},
+			want: true,
+		},
+		{
+			name: "scheduledStartTime in future",
+			details: port.VideoLiveDetails{
+				IsLiveContent:      true,
+				ActualStartTime:    now.Add(-1 * time.Minute),
+				ScheduledStartTime: now.Add(1 * time.Hour),
+			},
+			want: true,
+		},
+		{
+			name: "started",
+			details: port.VideoLiveDetails{
+				IsLiveContent:      true,
+				ActualStartTime:    now.Add(-10 * time.Minute),
+				ScheduledStartTime: now.Add(-15 * time.Minute),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := usecase.IsLiveNotStarted(tt.details, now)
+			if got != tt.want {
+				t.Errorf("IsLiveNotStarted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAutoRefresh } from './hooks/useAutoRefresh'
 import { useAppState } from './hooks/useAppState'
 import { useCommentSearch } from './hooks/useCommentSearch'
@@ -76,6 +76,12 @@ export default function App() {
     loadingStates,
   } = state
 
+  // 初回 mount 時に refresh を 1 度走らせて status / users を取得する
+  useEffect(() => {
+    void actions.refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // 名前読み上げタブの自動更新
   useAutoRefresh(intervalSec, actions.onPullSilent)
 
@@ -102,6 +108,8 @@ export default function App() {
             <Controls
               videoId={videoId}
               setVideoId={actions.setVideoId}
+              status={state.status}
+              currentVideoId={state.currentVideoId}
               loadingStates={loadingStates}
               onSwitch={handleSwitch}
               onPull={actions.onPull}

--- a/frontend/src/__tests__/App.handleSwitch.spec.tsx
+++ b/frontend/src/__tests__/App.handleSwitch.spec.tsx
@@ -89,7 +89,7 @@ describe('App - handleSwitch', () => {
 
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'VID_NEW' } })
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
 
     await waitFor(() => {
       expect(clearCommentsSpy).toHaveBeenCalledTimes(1)
@@ -101,7 +101,7 @@ describe('App - handleSwitch', () => {
 
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'VID_NEW' } })
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
 
     await waitFor(() => {
       expect(clearResultsSpy).toHaveBeenCalledTimes(1)
@@ -113,7 +113,7 @@ describe('App - handleSwitch', () => {
 
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'VID_NEW' } })
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
 
     await waitFor(() => {
       expect(clearCommentsSpy).toHaveBeenCalledTimes(1)

--- a/frontend/src/__tests__/App.handleSwitch.spec.tsx
+++ b/frontend/src/__tests__/App.handleSwitch.spec.tsx
@@ -6,15 +6,13 @@ import App from '../App'
 vi.mock('../utils/api', () => ({
   getStatus: vi.fn().mockResolvedValue({ status: 'ACTIVE', count: 0 }),
   getUsers: vi.fn().mockResolvedValue([]),
-  postSwitchVideo: vi.fn().mockResolvedValue({}),
-  postPull: vi
-    .fn()
-    .mockResolvedValue({
-      addedCount: 0,
-      skippedCount: 0,
-      autoReset: false,
-      pollingIntervalMillis: 15000,
-    }),
+  postSwitchVideo: vi.fn().mockResolvedValue({ status: 'ACTIVE' }),
+  postPull: vi.fn().mockResolvedValue({
+    addedCount: 0,
+    skippedCount: 0,
+    autoReset: false,
+    pollingIntervalMillis: 15000,
+  }),
   postReset: vi.fn().mockResolvedValue({}),
   searchComments: vi.fn().mockResolvedValue([]),
   HttpError: class HttpError extends Error {

--- a/frontend/src/__tests__/App.integration.spec.tsx
+++ b/frontend/src/__tests__/App.integration.spec.tsx
@@ -22,17 +22,25 @@ vi.mock('../hooks/useHistory', () => ({
 describe('App Integration (MSW)', () => {
   // 統合テスト用に長めのタイムアウトを設定
   vi.setConfig({ testTimeout: 12000 })
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
   test('切替成功で監視中表示になり、pull で人数が増える', async () => {
     let currentState: 'WAITING' | 'ACTIVE' = 'WAITING'
+    let currentVid: string | undefined
     const users: User[] = []
 
     server.use(
-      http.get('*/status', () => HttpResponse.json({ status: currentState, count: users.length })),
+      http.get('*/status', () =>
+        HttpResponse.json({ status: currentState, count: users.length, videoId: currentVid }),
+      ),
       http.get('*/users.json', () => HttpResponse.json(users)),
       http.post('*/switch-video', async ({ request }) => {
         try {
           const body = (await request.json()) as { videoId?: string }
           if (!body?.videoId) return new HttpResponse('bad request', { status: 400 })
+          currentVid = body.videoId
         } catch {
           return new HttpResponse('bad request', { status: 400 })
         }
@@ -64,13 +72,13 @@ describe('App Integration (MSW)', () => {
     expect(screen.getByText('0')).toBeInTheDocument()
 
     // videoId 未入力でエラー
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
     expect(await screen.findByRole('alert')).toBeInTheDocument()
 
     // 入力して切替
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'VID123' } })
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
     await waitFor(async () => {
       const activeEls = await screen.findAllByText('監視中')
       expect(activeEls[0]).toBeInTheDocument()
@@ -82,11 +90,14 @@ describe('App Integration (MSW)', () => {
   })
 
   test('初回コメント時間が正しく表示される', async () => {
+    localStorage.setItem('videoId', 'mock-vid')
     const mockDate = new Date('2024-01-01T10:30:00Z')
     const users: User[] = []
 
     server.use(
-      http.get('*/status', () => HttpResponse.json({ status: 'ACTIVE', count: users.length })),
+      http.get('*/status', () =>
+        HttpResponse.json({ status: 'ACTIVE', count: users.length, videoId: 'mock-vid' }),
+      ),
       http.get('*/users.json', () => HttpResponse.json(users)),
       http.post('*/pull', () => {
         users.push({
@@ -113,8 +124,8 @@ describe('App Integration (MSW)', () => {
     // ユーザーがいない時は「ユーザーがいません。」が表示される
     expect(screen.getByText('ユーザーがいません。')).toBeInTheDocument()
 
-    // 今すぐ取得でユーザーを追加
-    fireEvent.click(screen.getByRole('button', { name: '今すぐ取得' }))
+    // 今すぐ取得でユーザーを追加 (status 反映で ACTIVE 化を待つ)
+    fireEvent.click(await screen.findByRole('button', { name: '今すぐ取得' }))
 
     // 初回コメント時間が正しく表示される
     await waitFor(() => {
@@ -141,10 +152,13 @@ describe('App Integration (MSW)', () => {
   })
 
   test('手動「今すぐ取得」は「取得しました」メッセージが表示される', async () => {
+    localStorage.setItem('videoId', 'mock-vid')
     const users: User[] = []
 
     server.use(
-      http.get('*/status', () => HttpResponse.json({ status: 'ACTIVE', count: users.length })),
+      http.get('*/status', () =>
+        HttpResponse.json({ status: 'ACTIVE', count: users.length, videoId: 'mock-vid' }),
+      ),
       http.get('*/users.json', () => HttpResponse.json(users)),
       http.post('*/pull', () => {
         users.push({
@@ -168,7 +182,7 @@ describe('App Integration (MSW)', () => {
     expect(screen.getByText('ユーザーがいません。')).toBeInTheDocument()
 
     // 手動で「今すぐ取得」ボタンをクリック
-    fireEvent.click(screen.getByRole('button', { name: '今すぐ取得' }))
+    fireEvent.click(await screen.findByRole('button', { name: '今すぐ取得' }))
 
     // ユーザーが追加される
     await waitFor(() => {
@@ -217,6 +231,7 @@ describe('App Integration (MSW)', () => {
   })
 
   test('停止中(WAITING)でもユーザーリストが保持される', async () => {
+    localStorage.setItem('videoId', 'mock-vid')
     let currentStatus: 'WAITING' | 'ACTIVE' = 'ACTIVE'
     const users: User[] = [
       {
@@ -238,6 +253,7 @@ describe('App Integration (MSW)', () => {
         HttpResponse.json({
           status: currentStatus,
           count: users.length,
+          videoId: 'mock-vid',
           startedAt: currentStatus === 'ACTIVE' ? new Date().toISOString() : undefined,
         }),
       ),
@@ -255,7 +271,7 @@ describe('App Integration (MSW)', () => {
     render(<App />)
 
     // 手動でrefresh実行（MSWがレスポンスを確実に返すため）
-    const refreshButton = screen.getByRole('button', { name: '今すぐ取得' })
+    const refreshButton = await screen.findByRole('button', { name: '今すぐ取得' })
     fireEvent.click(refreshButton)
 
     // レスポンス後のユーザー表示を待つ
@@ -321,6 +337,7 @@ describe('App Integration (MSW)', () => {
   })
 
   test('切替実行時のみユーザーリストがクリアされる', async () => {
+    localStorage.setItem('videoId', 'mock-vid')
     const users: User[] = [
       {
         channelId: 'UC1',
@@ -335,6 +352,7 @@ describe('App Integration (MSW)', () => {
         return HttpResponse.json({
           status: 'ACTIVE',
           count: users.length,
+          videoId: 'mock-vid',
           startedAt: users.length > 0 ? new Date().toISOString() : undefined,
         })
       }),
@@ -359,7 +377,7 @@ describe('App Integration (MSW)', () => {
     render(<App />)
 
     // 手動でrefresh実行（MSWがレスポンスを確実に返すため）
-    const refreshBtn = screen.getByRole('button', { name: '今すぐ取得' })
+    const refreshBtn = await screen.findByRole('button', { name: '今すぐ取得' })
     fireEvent.click(refreshBtn)
 
     // 初期状態：ユーザーが読み込まれるまで待つ
@@ -383,7 +401,7 @@ describe('App Integration (MSW)', () => {
     // videoIdを入力して切替実行
     const input = screen.getByLabelText('videoId') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'new-video-123' } })
-    fireEvent.click(screen.getByRole('button', { name: '切替' }))
+    fireEvent.click(screen.getByRole('button', { name: '開始' }))
 
     // 切替後はリストがクリアされる（refreshWithClearが呼ばれる）
     await waitFor(

--- a/frontend/src/__tests__/App.integration.spec.tsx
+++ b/frontend/src/__tests__/App.integration.spec.tsx
@@ -46,7 +46,7 @@ describe('App Integration (MSW)', () => {
         }
         currentState = 'ACTIVE'
         users.length = 0 // 配列をクリア
-        return new HttpResponse(null, { status: 200 })
+        return HttpResponse.json({ status: 'ACTIVE', videoId: currentVid })
       }),
       http.post('*/pull', () => {
         users.push({
@@ -362,7 +362,7 @@ describe('App Integration (MSW)', () => {
       http.post('*/switch-video', () => {
         // 切替時にユーザーをクリア
         users.length = 0
-        return new HttpResponse(null, { status: 200 })
+        return HttpResponse.json({ status: 'ACTIVE', videoId: 'new-video-123' })
       }),
       http.post('*/pull', () =>
         HttpResponse.json({

--- a/frontend/src/__tests__/App.ui.spec.tsx
+++ b/frontend/src/__tests__/App.ui.spec.tsx
@@ -6,7 +6,7 @@ import App from '../App'
 vi.mock('../utils/api', () => ({
   getStatus: vi.fn().mockResolvedValue({ count: 0, active: false }),
   getUsers: vi.fn().mockResolvedValue([]),
-  postSwitchVideo: vi.fn().mockResolvedValue({}),
+  postSwitchVideo: vi.fn().mockResolvedValue({ status: 'ACTIVE' }),
   postPull: vi.fn().mockResolvedValue({}),
   postReset: vi.fn().mockResolvedValue({}),
 }))

--- a/frontend/src/components/Controls.tsx
+++ b/frontend/src/components/Controls.tsx
@@ -10,6 +10,8 @@ interface LoadingStates {
 interface ControlsProps {
   videoId: string
   setVideoId: (value: string) => void
+  status: string
+  currentVideoId?: string
   loadingStates: LoadingStates
   onSwitch: () => Promise<void>
   onPull: () => Promise<void>
@@ -19,11 +21,24 @@ interface ControlsProps {
 export function Controls({
   videoId,
   setVideoId,
+  status,
+  currentVideoId,
   loadingStates,
   onSwitch,
   onPull,
   onReset,
 }: ControlsProps) {
+  const isReserved = status === 'RESERVED'
+  const isActive = status === 'ACTIVE'
+  // ACTIVE 中: 入力 videoId が空 or 現行と一致 → Pull、別 video 入力中 → 開始 (= 切替)
+  // WAITING / RESERVED → 開始 (SwitchVideo dispatcher が reserve/switch を自動判別)
+  const sameVideo = !videoId || videoId === currentVideoId
+  const action: 'pull' | 'start' = isActive && sameVideo ? 'pull' : 'start'
+  const actionLabel = action === 'pull' ? '今すぐ取得' : '開始'
+  const actionLoading = action === 'pull' ? loadingStates.pulling : loadingStates.switching
+  const actionLoadingText = action === 'pull' ? '取得中…' : '開始中…'
+  const actionHandler = action === 'pull' ? onPull : onSwitch
+  const actionDisabled = isReserved
   return (
     <section aria-label="操作" className="card-editorial">
       <div className="eyebrow">
@@ -42,8 +57,8 @@ export function Controls({
               aria-label="videoId"
               value={videoId}
               onChange={(e) => setVideoId(e.target.value)}
-              placeholder="videoId を入力"
-              disabled={loadingStates.switching}
+              placeholder={isReserved ? '予約中 (キャンセルは curl)' : 'videoId を入力'}
+              disabled={actionLoading || actionDisabled}
               autoComplete="off"
               spellCheck={false}
               className="input-rule"
@@ -56,23 +71,16 @@ export function Controls({
               }}
             />
             <LoadingButton
-              ariaLabel="切替"
-              isLoading={loadingStates.switching}
-              loadingText="切替中…"
-              onClick={onSwitch}
+              ariaLabel={actionLabel}
+              isLoading={actionLoading}
+              loadingText={actionLoadingText}
+              onClick={actionHandler}
+              disabled={actionDisabled}
             >
-              切替
+              {actionLabel}
             </LoadingButton>
           </div>
           <div className="md:col-span-4 flex gap-2 justify-start md:justify-end">
-            <LoadingButton
-              ariaLabel="今すぐ取得"
-              isLoading={loadingStates.pulling}
-              loadingText="取得中…"
-              onClick={onPull}
-            >
-              今すぐ取得
-            </LoadingButton>
             <LoadingButton
               variant="outline"
               ariaLabel="リセット"

--- a/frontend/src/components/__tests__/Controls.spec.tsx
+++ b/frontend/src/components/__tests__/Controls.spec.tsx
@@ -6,6 +6,8 @@ describe('Controls コンポーネント', () => {
   const mockProps = {
     videoId: '',
     setVideoId: vi.fn(),
+    status: 'WAITING',
+
     loadingStates: {
       switching: false,
       pulling: false,
@@ -46,49 +48,75 @@ describe('Controls コンポーネント', () => {
     expect(mockProps.setVideoId).toHaveBeenCalledWith('new-video-id')
   })
 
-  test('操作ボタンが正しく表示される', () => {
+  test('WAITING 状態では「開始」ボタンとリセットボタンが表示される', () => {
     render(<Controls {...mockProps} />)
 
-    expect(screen.getByRole('button', { name: '切替' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '今すぐ取得' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '今すぐ取得' })).not.toBeInTheDocument()
   })
 
-  test('切替ボタンクリック時にonSwitchが呼ばれる', async () => {
-    render(<Controls {...mockProps} videoId="test-video" />)
+  test('ACTIVE 状態かつ入力 videoId が現行と一致なら「今すぐ取得」になる', () => {
+    render(<Controls {...mockProps} status="ACTIVE" videoId="vid001" currentVideoId="vid001" />)
 
-    const switchButton = screen.getByRole('button', { name: '切替' })
-    fireEvent.click(switchButton)
-
-    await waitFor(() => {
-      expect(mockProps.onSwitch).toHaveBeenCalled()
-    })
+    expect(screen.getByRole('button', { name: '今すぐ取得' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '開始' })).not.toBeInTheDocument()
   })
 
-  test('切替ボタンクリック時にonSwitchが呼ばれる', async () => {
+  test('ACTIVE 状態でも入力が空なら「今すぐ取得」', () => {
+    render(<Controls {...mockProps} status="ACTIVE" videoId="" currentVideoId="vid001" />)
+
+    expect(screen.getByRole('button', { name: '今すぐ取得' })).toBeInTheDocument()
+  })
+
+  test('ACTIVE 状態で別 videoId 入力中は「開始」(切替) になる', () => {
+    render(<Controls {...mockProps} status="ACTIVE" videoId="vid_new" currentVideoId="vid_old" />)
+
+    expect(screen.getByRole('button', { name: '開始' })).toBeInTheDocument()
+  })
+
+  test('RESERVED 状態では「開始」ボタンが disabled になる', () => {
+    render(<Controls {...mockProps} status="RESERVED" videoId="vid001" />)
+
+    const button = screen.getByRole('button', { name: '開始' })
+    expect(button).toBeDisabled()
+    const input = screen.getByRole('textbox', { name: 'videoId' })
+    expect(input).toHaveAttribute('placeholder', '予約中 (キャンセルは curl)')
+  })
+
+  test('「開始」クリック時に onSwitch が呼ばれる', async () => {
     const mockOnSwitch = vi.fn().mockResolvedValue(undefined)
-    render(<Controls {...mockProps} videoId="test-video-id" onSwitch={mockOnSwitch} />)
+    render(<Controls {...mockProps} videoId="vid001" onSwitch={mockOnSwitch} />)
 
-    const switchButton = screen.getByRole('button', { name: '切替' })
-    fireEvent.click(switchButton)
+    const button = screen.getByRole('button', { name: '開始' })
+    fireEvent.click(button)
 
     await waitFor(() => {
       expect(mockOnSwitch).toHaveBeenCalled()
     })
   })
 
-  test('今すぐ取得ボタンクリック時にonPullが呼ばれる', async () => {
-    render(<Controls {...mockProps} />)
+  test('「今すぐ取得」クリック時に onPull が呼ばれる', async () => {
+    const mockOnPull = vi.fn().mockResolvedValue(undefined)
+    render(
+      <Controls
+        {...mockProps}
+        status="ACTIVE"
+        videoId="vid001"
+        currentVideoId="vid001"
+        onPull={mockOnPull}
+      />,
+    )
 
-    const pullButton = screen.getByRole('button', { name: '今すぐ取得' })
-    fireEvent.click(pullButton)
+    const button = screen.getByRole('button', { name: '今すぐ取得' })
+    fireEvent.click(button)
 
     await waitFor(() => {
-      expect(mockProps.onPull).toHaveBeenCalled()
+      expect(mockOnPull).toHaveBeenCalled()
     })
   })
 
-  test('リセットボタンクリック時にconfirm を通過すると onReset が呼ばれる', async () => {
+  test('リセットボタンクリック時に confirm を通過すると onReset が呼ばれる', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     render(<Controls {...mockProps} />)
 
@@ -112,7 +140,7 @@ describe('Controls コンポーネント', () => {
     confirmSpy.mockRestore()
   })
 
-  test('ローディング状態でボタンが無効化される', () => {
+  test('switching 中はボタンと入力欄が無効化される', () => {
     const loadingStates = {
       switching: true,
       pulling: false,
@@ -122,20 +150,27 @@ describe('Controls コンポーネント', () => {
     render(<Controls {...mockProps} loadingStates={loadingStates} />)
 
     const input = screen.getByRole('textbox', { name: 'videoId' })
-    const switchButton = screen.getByRole('button', { name: /切替/ })
-
     expect(input).toBeDisabled()
-    expect(switchButton).toHaveAttribute('aria-busy', 'true')
+    const button = screen.getByRole('button', { name: /開始/ })
+    expect(button).toHaveAttribute('aria-busy', 'true')
   })
 
-  test('ローディング中の表示が正しい', () => {
+  test('pulling 中は「取得中…」が表示される', () => {
     const loadingStates = {
       switching: false,
       pulling: true,
       resetting: false,
       refreshing: false,
     }
-    render(<Controls {...mockProps} loadingStates={loadingStates} />)
+    render(
+      <Controls
+        {...mockProps}
+        status="ACTIVE"
+        videoId="vid001"
+        currentVideoId="vid001"
+        loadingStates={loadingStates}
+      />,
+    )
 
     expect(screen.getByRole('button', { name: '取得中…' })).toBeInTheDocument()
   })

--- a/frontend/src/hooks/__tests__/useAppState.spec.tsx
+++ b/frontend/src/hooks/__tests__/useAppState.spec.tsx
@@ -63,6 +63,7 @@ describe('useAppState', () => {
       reserved: false,
       users: [],
       videoId: '',
+      currentVideoId: undefined,
       intervalSec: 60,
       lastUpdated: '--:--:--',
       lastFetchTime: '',

--- a/frontend/src/hooks/__tests__/useAppState.spec.tsx
+++ b/frontend/src/hooks/__tests__/useAppState.spec.tsx
@@ -156,7 +156,7 @@ describe('useAppState', () => {
   })
 
   test('onSwitch関数がvideoIdありで成功する', async () => {
-    mockPostSwitchVideo.mockResolvedValue(undefined)
+    mockPostSwitchVideo.mockResolvedValue({ status: 'ACTIVE' })
     mockPostPull.mockResolvedValue({ addedCount: 0, skippedCount: 0, autoReset: false })
     mockGetStatus.mockResolvedValue({ status: 'ACTIVE' })
     mockGetUsers.mockResolvedValue([])
@@ -174,6 +174,26 @@ describe('useAppState', () => {
     expect(mockPostSwitchVideo).toHaveBeenCalledWith('test-video', expect.any(AbortSignal))
     expect(localStorage.getItem('videoId')).toBe('test-video')
     expect(result.current.state.infoMsg).toBe('切替しました')
+  })
+
+  test('onSwitch関数がRESERVEDの場合は予約メッセージを表示しpullしない', async () => {
+    mockPostSwitchVideo.mockResolvedValue({ status: 'RESERVED' })
+    mockGetStatus.mockResolvedValue({ status: 'RESERVED', videoId: 'test-video' })
+    mockGetUsers.mockResolvedValue([])
+
+    const { result } = renderHook(() => useAppState())
+
+    act(() => {
+      result.current.actions.setVideoId('test-video')
+    })
+
+    await act(async () => {
+      await result.current.actions.onSwitch()
+    })
+
+    expect(mockPostSwitchVideo).toHaveBeenCalledWith('test-video', expect.any(AbortSignal))
+    expect(mockPostPull).not.toHaveBeenCalled()
+    expect(result.current.state.infoMsg).toBe('予約しました（配信開始を待機中）')
   })
 
   test('onPull関数が成功し、lastFetchTimeを更新する', async () => {

--- a/frontend/src/hooks/useAppState.ts
+++ b/frontend/src/hooks/useAppState.ts
@@ -61,6 +61,7 @@ interface AppState {
   status: string
   users: User[]
   videoId: string
+  currentVideoId?: string
   intervalSec: number
   lastUpdated: string
   lastFetchTime: string
@@ -97,6 +98,7 @@ export function useAppState(addEntry?: AddEntryFn) {
     status: 'WAITING',
     users: [],
     videoId: localStorage.getItem('videoId') || '',
+    currentVideoId: undefined,
     intervalSec: 60,
     lastUpdated: '--:--:--',
     lastFetchTime: '',
@@ -183,6 +185,7 @@ export function useAppState(addEntry?: AddEntryFn) {
             users: finalUsers,
             startTime: st.startedAt,
             scheduledStartTime: st.scheduledStartTime,
+            currentVideoId: st.videoId,
             errorMsg: '',
             lastSnapshotAt: newSnapshotAt ?? prev.lastSnapshotAt,
             ...(snapshotRestoreMsg ? { snapshotRestoreMsg } : {}),

--- a/frontend/src/hooks/useAppState.ts
+++ b/frontend/src/hooks/useAppState.ts
@@ -222,7 +222,9 @@ export function useAppState(addEntry?: AddEntryFn) {
 
   const handleAsyncAction = useCallback(
     async (
-      action: (signal: AbortSignal) => Promise<void>,
+      action: (
+        signal: AbortSignal,
+      ) => Promise<{ successMsg?: string; clearUsers?: boolean } | void>,
       loadingKey: keyof LoadingStates,
       successMsg: string,
       errorMsgPrefix: string = '',
@@ -244,12 +246,16 @@ export function useAppState(addEntry?: AddEntryFn) {
         const controller = new AbortController()
         controllerRef.current = controller
 
-        await action(controller.signal)
+        const actionResult = await action(controller.signal)
 
         // リクエストが成功したらcontrollerをクリア
         controllerRef.current = null
 
-        setState((prev) => ({ ...prev, errorMsg: '', infoMsg: successMsg }))
+        setState((prev) => ({
+          ...prev,
+          errorMsg: '',
+          infoMsg: actionResult?.successMsg ?? successMsg,
+        }))
 
         // 取得系アクション（pulling）の場合は取得時刻を更新
         if (loadingKey === 'pulling') {
@@ -260,7 +266,7 @@ export function useAppState(addEntry?: AddEntryFn) {
         }
 
         // 切替・リセット時はユーザーリストをクリア、それ以外は保持
-        await refresh({ clearUsers: shouldClearUsers })
+        await refresh({ clearUsers: actionResult?.clearUsers ?? shouldClearUsers })
       } catch (e) {
         // AbortErrorの場合はエラーメッセージを表示しない
         if (e instanceof Error && e.name === 'AbortError') {
@@ -328,16 +334,23 @@ export function useAppState(addEntry?: AddEntryFn) {
       setState((prev) => ({ ...prev, skippedCount: 0 }))
       await handleAsyncAction(
         async (signal) => {
-          await postSwitchVideo(state.videoId, signal)
+          const res = await postSwitchVideo(state.videoId, signal)
           localStorage.setItem('videoId', state.videoId)
+          if (res.status === 'RESERVED') {
+            addEntry?.('info', `配信予約: ${state.videoId}`)
+            return {
+              successMsg: '予約しました（配信開始を待機中）',
+              clearUsers: false,
+            }
+          }
           addEntry?.('info', `配信切替: ${state.videoId}`)
           await pullAction(signal)
+          return { successMsg: '切替しました', clearUsers: true }
         },
         'switching',
         '切替しました',
         '切替',
         switchControllerRef,
-        true, // 切替時はユーザーリストをクリア
       )
     }, [state.videoId, handleAsyncAction, addEntry, pullAction]),
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -9,18 +9,20 @@ type User = {
 }
 
 // 簡易なメモリ状態（各テストで server.use で上書き可）
-let state: 'WAITING' | 'ACTIVE' = 'WAITING'
+let state: 'WAITING' | 'ACTIVE' | 'RESERVED' = 'WAITING'
 let users: User[] = []
+let videoId: string | undefined
 
 export const resetMockState = () => {
   state = 'WAITING'
   users = []
+  videoId = undefined
 }
 
 export const handlers = [
   // 状態
   http.get('*/status', () => {
-    return HttpResponse.json({ status: state, count: users.length })
+    return HttpResponse.json({ status: state, count: users.length, videoId })
   }),
 
   // ユーザー一覧
@@ -34,6 +36,7 @@ export const handlers = [
     try {
       const body = (await request.json()) as { videoId?: string }
       if (!body?.videoId) return new HttpResponse('bad request', { status: 400 })
+      videoId = body.videoId
     } catch {
       return new HttpResponse('bad request', { status: 400 })
     }
@@ -49,7 +52,7 @@ export const handlers = [
       channelId: `UC${users.length + 1}`,
       displayName: `User-${users.length + 1}`,
       joinedAt: now,
-      firstCommentedAt: now  // 初回コメント日時を設定
+      firstCommentedAt: now, // 初回コメント日時を設定
     })
     return new HttpResponse(null, { status: 200 })
   }),
@@ -58,6 +61,7 @@ export const handlers = [
   http.post('*/reset', () => {
     state = 'WAITING'
     users = []
+    videoId = undefined
     return new HttpResponse(null, { status: 200 })
   }),
 ]
@@ -66,7 +70,7 @@ export const __mock = {
   get state() {
     return state
   },
-  set state(v: 'WAITING' | 'ACTIVE') {
+  set state(v: 'WAITING' | 'ACTIVE' | 'RESERVED') {
     state = v
   },
   get users() {

--- a/frontend/src/utils/api.test.ts
+++ b/frontend/src/utils/api.test.ts
@@ -100,12 +100,12 @@ describe('API functions', () => {
     test('正常にビデオ切替リクエストを送信', async () => {
       server.use(
         http.post('*/switch-video', () => {
-          return new HttpResponse(null, { status: 200 })
+          return HttpResponse.json({ status: 'ACTIVE' })
         }),
       )
 
-      await postSwitchVideo('test-video')
-      // 例外が投げられなければ成功
+      const res = await postSwitchVideo('test-video')
+      expect(res.status).toBe('ACTIVE')
     })
 
     test('AbortSignalを正しく渡す', async () => {
@@ -113,7 +113,7 @@ describe('API functions', () => {
 
       server.use(
         http.post('*/switch-video', () => {
-          return new HttpResponse(null, { status: 200 })
+          return HttpResponse.json({ status: 'ACTIVE' })
         }),
       )
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -96,14 +96,27 @@ export async function getUsers(signal?: AbortSignal): Promise<User[] | null> {
   return json<User[] | null>(res)
 }
 
-export async function postSwitchVideo(videoId: string, signal?: AbortSignal): Promise<void> {
+export type SwitchVideoResponse = {
+  status: 'WAITING' | 'ACTIVE' | 'RESERVED'
+  videoId?: string
+  liveChatId?: string
+  startedAt?: string
+  scheduledStartTime?: string
+  reservedAt?: string
+  logs?: LogDetail[]
+}
+
+export async function postSwitchVideo(
+  videoId: string,
+  signal?: AbortSignal,
+): Promise<SwitchVideoResponse> {
   const res = await fetch(`${BASE}/switch-video`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ videoId }),
     signal,
   })
-  await throwIfError(res)
+  return json<SwitchVideoResponse>(res)
 }
 
 export type BackendLog = {


### PR DESCRIPTION
## Summary
- frontend: 「切替」「今すぐ取得」を 1 ボタンに統合。WAITING/RESERVED → 「開始」、ACTIVE で同一 videoId → 「今すぐ取得」、ACTIVE で別 videoId 入力中 → 「開始」(切替)。RESERVED 時は disabled。
- backend: `/switch-video` ハンドラに dispatcher を追加。`GetVideoLiveDetails` で actualStartTime と scheduledStartTime を確認し、未開始 (actualStartTime zero または scheduledStartTime 未来) なら Reserve usecase に自動振り分け。レスポンス `SwitchVideoResponse` に `scheduledStartTime` / `reservedAt` フィールド追加。
- `SwitchVideoResponse` 互換: 既存 ACTIVE 経路は変更なし、Reserve 経路時のみ status=RESERVED + scheduledStartTime が入る。

## 背景
PR #82 で curl 想定の `/reserve` を追加したが frontend UI は未着手で、未開始配信に「切替」を押すと chat だけ open してる premiere/test broadcast 状態でも SwitchVideo が即成功し ACTIVE に化けていた (`5h4MFyAqZ1c` 明日 09:00 配信で再現)。ユーザは入力 + 1 ボタンだけで「予約も切替も取得も」自動判別されることを期待していたため、backend の `/switch-video` に dispatcher を入れ、frontend は状態に応じてボタン挙動を切替える形に統合した。

## Test plan
- [x] backend: `go build ./... && go test ./...` 全 green
- [x] frontend: `npm run build && npx vitest run` 全 375 test green、`npx tsc --noEmit` 0 error
- [ ] merge 後 Cloud Run deploy 完了確認
- [ ] 本番で /reset → 未開始 videoId (明日の配信) を frontend に入力 → 「開始」押下 → status RESERVED + StatsCard「予約中」+ 開始予定時刻表示確認
- [ ] 開始済 videoId で同操作 → ACTIVE 即遷移確認